### PR TITLE
feat(json): Add `sincpp::to_json_value` function for 1D containers

### DIFF
--- a/examples/json/to_json_value.cpp
+++ b/examples/json/to_json_value.cpp
@@ -2,10 +2,33 @@
 
 #include <iostream>
 
+template <class C> void print(C const &c) {
+  for (auto const &e : c) {
+    std::cout << e << " ";
+  }
+  std::cout << std::endl;
+}
+
 int main() {
   std::cout << sincpp::to_json_value(3.14f).to_json() << std::endl; // 3.14
   std::cout << sincpp::to_json_value('c') << std::endl;             // c
   std::cout << sincpp::to_json_value("A string") << std::endl;      // A string
+
+  int const c_array_i[] = {1, 2, 3};
+  char const c_array_s[] = {'a', 'b', 'c'};
+  std::array<int, 3> const array_i = {21, 42, 73};
+  std::array<std::string, 2> const array_s = {"An", "array"};
+  print(sincpp::to_json_value(c_array_i)); // 1 2 3
+  print(sincpp::to_json_value(c_array_s)); // a b c
+  print(sincpp::to_json_value(array_i));   // 21 42 73
+  print(sincpp::to_json_value(array_s));   // An array
+
+  std::vector<char const *> const vector = {"A", "std::vector"};
+  std::list<std::string_view> const list = {"A", "std::list"};
+  std::set<std::string> const set = {"A", "std::set"};
+  print(sincpp::to_json_value(vector)); // A std::vector
+  print(sincpp::to_json_value(list));   // A std::list
+  print(sincpp::to_json_value(set));    // A std::set
 
   return 0;
 }

--- a/include/sincpp/json/to_json_value.hpp
+++ b/include/sincpp/json/to_json_value.hpp
@@ -23,8 +23,12 @@
 
 #include "../str/conv.hpp"
 #include "../type_traits/is_char.hpp"
+#include "../type_traits/is_container_1d.hpp"
 #include "../type_traits/is_string.hpp"
 
+#include <algorithm>
+#include <iostream>
+#include <ranges>
 #include <string_view>
 #include <type_traits>
 
@@ -70,6 +74,13 @@ public:
   /// @brief Get the JSON representation.
   /// @returns the JSON representation.
   std::string_view to_json() const { return {m_str.data(), m_size}; }
+
+  /// @brief Operator `<<` between a `std::ostream` and a number.
+  /// @param o A `std::ostream`.
+  /// @param n A number.
+  friend std::ostream &operator<<(std::ostream &o, number_str_t const &n) {
+    return o << n.to_json();
+  }
 };
 
 /**
@@ -133,6 +144,168 @@ template <class T>
   requires(std::is_arithmetic_v<T> && is_char_v<T> == false)
 number_str_t<sincpp::to_chars_max_size<T>()> to_json_value(T const t) {
   return number_str_t<sincpp::to_chars_max_size<T>()>(t);
+}
+
+// to_json_value: array
+
+/**
+ * @brief Get the JSON value of an array of strings.
+ *
+ * @tparam T String type.
+ * @tparam N Array size.
+ * @tparam A Array of strings type.
+ *
+ * @param a An array of strings.
+ *
+ * @returns the JSON value of the array of strings.
+ */
+template <class T, size_t N, class A>
+  requires(is_string_v<T> || is_char_v<T>)
+A const &array_to_json_value(A const &a) {
+  return a;
+}
+
+/**
+ * @brief Get the JSON value of an array of numbers.
+ *
+ * @tparam T String type.
+ * @tparam N Array size.
+ * @tparam A Array of numbers type.
+ *
+ * @param a An array of numbers.
+ *
+ * @returns the JSON value of the array of numbers.
+ */
+template <class T, size_t N, class A>
+  requires(std::is_arithmetic_v<T>)
+std::array<number_str_t<to_chars_max_size<T>()>, N>
+array_to_json_value(A const &a) {
+  std::array<number_str_t<to_chars_max_size<T>()>, N> r;
+  std::ranges::transform(a, r.begin(),
+                         [](T const v) { return make_number_str(v); });
+  return r;
+}
+
+/**
+ * @brief Get the JSON value of an array.
+ *
+ * @tparam T String type.
+ * @tparam N Array size.
+ *
+ * @param a An array.
+ *
+ * @returns the JSON value of the array.
+ *
+ * **Example:**
+ * @include examples/json/to_json_value.cpp
+ */
+template <class T, size_t N>
+auto to_json_value(std::array<T, N> const &a)
+    -> decltype(array_to_json_value<T, N>(a)) {
+  return array_to_json_value<T, N>(a);
+}
+
+// to_json_value: C array
+
+/**
+ * @brief Get the JSON value of a C array of numbers.
+ *
+ * @tparam T Number type.
+ * @tparam N Array size.
+ *
+ * @param a A C array of numbers.
+ *
+ * @returns the JSON value of the C array of numbers.
+ *
+ * **Example:**
+ * @include examples/json/to_json_value.cpp
+ */
+template <class T, size_t N>
+  requires(std::is_arithmetic_v<T> && std::is_same_v<T, char> == false)
+std::array<number_str_t<to_chars_max_size<T>()>, N>
+to_json_value(T const (&a)[N]) {
+  std::array<number_str_t<to_chars_max_size<T>()>, N> r;
+  std::transform(a, a + N, r.begin(),
+                 [](T const v) { return make_number_str(v); });
+  return r;
+}
+
+/**
+ * @brief Get the JSON value of a C array of strings.
+ *
+ * @tparam T String type.
+ * @tparam N Array size.
+ *
+ * @param a A C array of strings.
+ *
+ * @returns the JSON value of the C array of strings.
+ *
+ * **Example:**
+ * @include examples/json/to_json_value.cpp
+ */
+template <class T, int N>
+  requires(is_string_v<T>)
+std::array<std::string_view, N> to_json_value(T const (&a)[N]) {
+  std::array<std::string_view, N> r;
+  std::ranges::copy(a, a + N, r.begin());
+  return r;
+}
+
+// to_json_value: 1D container
+
+/**
+ * @brief Get the JSON value of an 1D container of strings.
+ *
+ * @tparam T String type.
+ * @tparam C 1D container of strings type.
+ *
+ * @param c An 1D container of strings.
+ *
+ * @returns the JSON value of the 1D container of strings.
+ */
+template <class T, class C>
+  requires(is_string_v<T> || is_char_v<T>)
+C const &container_1d_to_json_value(C const &c) {
+  return c;
+}
+
+/**
+ * @brief Get the JSON value of an 1D container of numbers.
+ *
+ * @tparam T Number type.
+ * @tparam C 1D container of numbers type.
+ *
+ * @param c An 1D container of numbers.
+ *
+ * @returns the JSON value of the 1D container of numbers.
+ */
+template <class T, class C>
+  requires(std::is_arithmetic_v<T>)
+std::vector<number_str_t<to_chars_max_size<T>()>>
+container_1d_to_json_value(C const &c) {
+  std::vector<number_str_t<to_chars_max_size<T>()>> r(c.size());
+  std::ranges::transform(c, r.begin(),
+                         [](T const v) { return make_number_str(v); });
+  return r;
+}
+
+/**
+ * @brief Get the JSON value of an 1D container.
+ *
+ * @tparam C 1D container type.
+ *
+ * @param c An 1D container.
+ *
+ * @returns the JSON value of the 1D container.
+ *
+ * **Example:**
+ * @include examples/json/to_json_value.cpp
+ */
+template <class C>
+  requires(is_container_1d_v<C>)
+auto to_json_value(C const &c)
+    -> decltype(container_1d_to_json_value<typename C::value_type>(c)) {
+  return container_1d_to_json_value<typename C::value_type>(c);
 }
 
 } // namespace sincpp

--- a/tests/json/to_json_value.cpp
+++ b/tests/json/to_json_value.cpp
@@ -20,6 +20,8 @@
 
 #include <sincpp/json/to_json_value.hpp>
 
+#include <sstream>
+
 #include <gtest/gtest.h>
 
 // number
@@ -53,6 +55,14 @@ TEST(to_json_value, number) {
   EXPECT_EQ(sincpp::to_json_value(21.42).to_json(), "21.42");
 }
 
+TEST(to_json_value, ostream) {
+  std::stringstream out;
+  out << sincpp::to_json_value(42) << " "    //
+      << sincpp::to_json_value(3.14f) << " " //
+      << sincpp::to_json_value(21.42);
+  EXPECT_EQ(out.str(), "42 3.14 21.42");
+}
+
 // string
 
 TEST(to_json_value, char) { EXPECT_EQ(sincpp::to_json_value('c'), 'c'); }
@@ -80,4 +90,170 @@ TEST(to_json_value, c_char_array) {
   auto const &v = sincpp::to_json_value(c_array);
   static_assert(std::is_same_v<decltype(v), char const(&)[10]>);
   EXPECT_EQ(&v, &c_array);
+}
+
+// array, vector, list, deque, set, unordered_set
+
+template <class C>
+void test_container_number_check(C const &v,
+                                 std::vector<std::string> const &expected) {
+  EXPECT_EQ(v.size(), expected.size());
+  for (size_t i = 0; i < v.size(); ++i) {
+    EXPECT_EQ(v[i].to_json_size(), expected[i].size());
+    EXPECT_EQ(v[i].to_json(), expected[i]);
+  }
+}
+
+template <class C>
+void test_container_number(C const &c,
+                           std::vector<std::string> const &expected) {
+  using T = typename C::value_type;
+  std::vector<sincpp::number_str_t<sincpp::to_chars_max_size<T>()>> const v =
+      sincpp::to_json_value(c);
+  test_container_number_check(v, expected);
+}
+
+template <class T, size_t N>
+void test_container_number(std::array<T, N> const &c,
+                           std::vector<std::string> const &expected) {
+  std::array<sincpp::number_str_t<sincpp::to_chars_max_size<T>()>, N> const v =
+      sincpp::to_json_value(c);
+  test_container_number_check(v, expected);
+}
+
+template <class T, size_t N>
+void test_container_number(std::array<std::string_view, N> const &c,
+                           std::vector<std::string> const &expected) {
+  std::array<sincpp::number_str_t<sincpp::to_chars_max_size<T>()>, N> const v =
+      sincpp::to_json_value(c);
+  test_container_number_check(v, expected);
+}
+
+template <class C> void test_container_string(C const &c) {
+  C const &v = sincpp::to_json_value(c);
+  EXPECT_EQ(&v, &c);
+}
+
+template <class T, size_t N>
+void test_container_string(T const (&a)[N],
+                           std::vector<std::string> const &expected) {
+  std::array<std::string_view, N> const v = sincpp::to_json_value(a);
+  EXPECT_EQ(v.size(), expected.size());
+  for (size_t i = 0; i < v.size(); ++i) {
+    EXPECT_EQ(v[i], expected[i]);
+  }
+}
+
+TEST(to_json_value, container_number) {
+  test_container_number(std::array<int, 0>(), {});
+  test_container_number(std::array<int, 4>({7, 21, 42, 73}),
+                        {"7", "21", "42", "73"});
+  test_container_number(std::array<float, 2>({3.14f, 21.42f}),
+                        {"3.14", "21.42"});
+  test_container_number(std::array<double, 2>({3.14, 21.42}),
+                        {"3.14", "21.42"});
+
+  test_container_number(std::vector<int>(), {});
+  test_container_number(std::vector<int>({7, 21, 42, 73}),
+                        {"7", "21", "42", "73"});
+  test_container_number(std::vector<float>({3.14f, 21.42f}), {"3.14", "21.42"});
+  test_container_number(std::vector<double>({3.14, 21.42}), {"3.14", "21.42"});
+
+  test_container_number(std::list<int>(), {});
+  test_container_number(std::list<int>({7, 21, 42, 73}),
+                        {"7", "21", "42", "73"});
+  test_container_number(std::list<float>({3.14f, 21.42f}), {"3.14", "21.42"});
+  test_container_number(std::list<double>({3.14, 21.42}), {"3.14", "21.42"});
+
+  test_container_number(std::deque<int>(), {});
+  test_container_number(std::deque<int>({7, 21, 42, 73}),
+                        {"7", "21", "42", "73"});
+  test_container_number(std::deque<float>({3.14f, 21.42f}), {"3.14", "21.42"});
+  test_container_number(std::deque<double>({3.14, 21.42}), {"3.14", "21.42"});
+
+  test_container_number(std::set<int>(), {});
+  test_container_number(std::set<int>({7, 21, 42, 73}),
+                        {"7", "21", "42", "73"});
+  test_container_number(std::set<float>({3.14f, 21.42f}), {"3.14", "21.42"});
+  test_container_number(std::set<double>({3.14, 21.42}), {"3.14", "21.42"});
+
+  test_container_number(std::unordered_set<int>(), {});
+  test_container_number(std::unordered_set<int>({73}), {"73"});
+  test_container_number(std::unordered_set<float>({3.14f}), {"3.14"});
+  test_container_number(std::unordered_set<double>({21.42}), {"21.42"});
+}
+
+TEST(to_json_value, container_string) {
+  test_container_string(std::array<std::string, 0>());
+  test_container_string(std::array<std::string_view, 0>());
+  test_container_string(std::array<char const *, 0>());
+  test_container_string(
+      std::array<std::string, 4>({"A", "std::array", "of", "std::string"}));
+  test_container_string(std::array<std::string_view, 4>(
+      {"A", "std::array", "of", "std::string_view"}));
+  test_container_string(
+      std::array<char const *, 4>({"A", "std::array", "of", "char const *"}));
+
+  {
+    std::string const a[] = {"A", "C array", "of", "std::string"};
+    test_container_string(a, {"A", "C array", "of", "std::string"});
+  }
+  {
+    std::string const a[] = {"A", "C array", "of", "std::string_view"};
+    test_container_string(a, {"A", "C array", "of", "std::string_view"});
+  }
+  {
+    std::string const a[] = {"A", "C array", "of", "char const *"};
+    test_container_string(a, {"A", "C array", "of", "char const *"});
+  }
+
+  test_container_string(std::vector<std::string>());
+  test_container_string(std::vector<std::string_view>());
+  test_container_string(std::vector<char const *>());
+  test_container_string(
+      std::vector<std::string>({"A", "std::vector", "of", "std::string"}));
+  test_container_string(std::vector<std::string_view>(
+      {"A", "std::vector", "of", "std::string_view"}));
+  test_container_string(
+      std::vector<char const *>({"A", "std::vector", "of", "char const *"}));
+
+  test_container_string(std::list<std::string>());
+  test_container_string(std::list<std::string_view>());
+  test_container_string(std::list<char const *>());
+  test_container_string(
+      std::list<std::string>({"A", "std::list", "of", "std::string"}));
+  test_container_string(std::list<std::string_view>(
+      {"A", "std::list", "of", "std::string_view"}));
+  test_container_string(
+      std::list<char const *>({"A", "std::list", "of", "char const *"}));
+
+  test_container_string(std::deque<std::string>());
+  test_container_string(std::deque<std::string_view>());
+  test_container_string(std::deque<char const *>());
+  test_container_string(
+      std::deque<std::string>({"A", "std::deque", "of", "std::string"}));
+  test_container_string(std::deque<std::string_view>(
+      {"A", "std::deque", "of", "std::string_view"}));
+  test_container_string(
+      std::deque<char const *>({"A", "std::deque", "of", "char const *"}));
+
+  test_container_string(std::set<std::string>());
+  test_container_string(std::set<std::string_view>());
+  test_container_string(std::set<char const *>());
+  test_container_string(
+      std::set<std::string>({"A", "std::set", "of", "std::string"}));
+  test_container_string(
+      std::set<std::string_view>({"A", "std::set", "of", "std::string_view"}));
+  test_container_string(
+      std::set<char const *>({"A", "std::set", "of", "char const *"}));
+
+  test_container_string(std::unordered_set<std::string>());
+  test_container_string(std::unordered_set<std::string_view>());
+  test_container_string(std::unordered_set<char const *>());
+  test_container_string(std::unordered_set<std::string>(
+      {"A", "std::unordered_set", "of", "std::string"}));
+  test_container_string(std::unordered_set<std::string_view>(
+      {"A", "std::unordered_set", "of", "std::string_view"}));
+  test_container_string(std::unordered_set<char const *>(
+      {"A", "std::unordered_set", "of", "char const *"}));
 }


### PR DESCRIPTION
Change:
- Add `sincpp::to_json_value` for 1D containers (C array, `std::array`, `std::vector`, `std::list`, `std::deque`, `std::set` and `std::unordered_set`)