### PR TITLE
ci: Update for new runners

### DIFF
--- a/.github/workflows/ci_generated.yml
+++ b/.github/workflows/ci_generated.yml
@@ -77,7 +77,7 @@ jobs:
       #      -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
       #      -GNinja \
       #      -DCMAKE_INSTALL_PREFIX=../_install \
-      #      -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
+      #      -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
       #    cmake --build build --target install
       - name: Google Test
         shell: bash
@@ -91,7 +91,7 @@ jobs:
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -GNinja \
             -DCMAKE_INSTALL_PREFIX=../_install \
-            -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
+            -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
           cmake --build build --target install
       - name: zlib
         shell: bash
@@ -104,7 +104,7 @@ jobs:
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -GNinja \
             -DCMAKE_INSTALL_PREFIX=../_install \
-            -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
+            -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
           cmake --build build --target install
 
       # sin-cpp
@@ -117,7 +117,7 @@ jobs:
           -G"`python3 -c "import random; print(random.choice(['Ninja', 'Unix Makefiles']))"`" \
           -DCMAKE_INSTALL_PREFIX=../_install \
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-          -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
+          -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
       - name: Build
         shell: bash
         run: |
@@ -198,7 +198,7 @@ jobs:
       #      -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
       #      -GNinja \
       #      -DCMAKE_INSTALL_PREFIX=../_install \
-      #      -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc
+      #      -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
       #    cmake --build build --target install
       - name: Google Test
         shell: bash
@@ -212,7 +212,7 @@ jobs:
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -GNinja \
             -DCMAKE_INSTALL_PREFIX=../_install \
-            -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc
+            -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
           cmake --build build --target install
       - name: zlib
         shell: bash
@@ -225,7 +225,7 @@ jobs:
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -GNinja \
             -DCMAKE_INSTALL_PREFIX=../_install \
-            -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc
+            -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
           cmake --build build --target install
 
       # sin-cpp
@@ -238,7 +238,7 @@ jobs:
           -G"`python3 -c "import random; print(random.choice(['Ninja', 'Unix Makefiles']))"`" \
           -DCMAKE_INSTALL_PREFIX=../_install \
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-          -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc
+          -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
       - name: Build
         shell: bash
         run: |
@@ -321,7 +321,7 @@ jobs:
       #      -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
       #      -GNinja \
       #      -DCMAKE_INSTALL_PREFIX=../_install \
-      #      -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
+      #      -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
       #    cmake --build build --target install
       - name: Google Test
         shell: bash
@@ -335,7 +335,7 @@ jobs:
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -GNinja \
             -DCMAKE_INSTALL_PREFIX=../_install \
-            -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
+            -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
           cmake --build build --target install
       - name: zlib
         shell: bash
@@ -348,7 +348,7 @@ jobs:
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -GNinja \
             -DCMAKE_INSTALL_PREFIX=../_install \
-            -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
+            -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
           cmake --build build --target install
 
       # sin-cpp
@@ -361,7 +361,7 @@ jobs:
           -G"`python3 -c "import random; print(random.choice(['Ninja', 'Unix Makefiles']))"`" \
           -DCMAKE_INSTALL_PREFIX=../_install \
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-          -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
+          -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
       - name: Build
         shell: bash
         run: |
@@ -442,7 +442,7 @@ jobs:
       #      -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
       #      -GNinja \
       #      -DCMAKE_INSTALL_PREFIX=../_install \
-      #      -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc
+      #      -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
       #    cmake --build build --target install
       - name: Google Test
         shell: bash
@@ -456,7 +456,7 @@ jobs:
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -GNinja \
             -DCMAKE_INSTALL_PREFIX=../_install \
-            -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc
+            -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
           cmake --build build --target install
       - name: zlib
         shell: bash
@@ -469,7 +469,7 @@ jobs:
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -GNinja \
             -DCMAKE_INSTALL_PREFIX=../_install \
-            -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc
+            -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
           cmake --build build --target install
 
       # sin-cpp
@@ -482,7 +482,7 @@ jobs:
           -G"`python3 -c "import random; print(random.choice(['Ninja', 'Unix Makefiles']))"`" \
           -DCMAKE_INSTALL_PREFIX=../_install \
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-          -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc
+          -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
       - name: Build
         shell: bash
         run: |
@@ -565,7 +565,7 @@ jobs:
       #      -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
       #      -GNinja \
       #      -DCMAKE_INSTALL_PREFIX=../_install \
-      #      -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
+      #      -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
       #    cmake --build build --target install
       - name: Google Test
         shell: bash
@@ -579,7 +579,7 @@ jobs:
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -GNinja \
             -DCMAKE_INSTALL_PREFIX=../_install \
-            -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
+            -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
           cmake --build build --target install
       - name: zlib
         shell: bash
@@ -592,7 +592,7 @@ jobs:
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -GNinja \
             -DCMAKE_INSTALL_PREFIX=../_install \
-            -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
+            -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
           cmake --build build --target install
 
       # sin-cpp
@@ -605,7 +605,7 @@ jobs:
           -G"`python3 -c "import random; print(random.choice(['Ninja', 'Unix Makefiles']))"`" \
           -DCMAKE_INSTALL_PREFIX=../_install \
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-          -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
+          -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
       - name: Build
         shell: bash
         run: |
@@ -686,7 +686,7 @@ jobs:
       #      -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
       #      -GNinja \
       #      -DCMAKE_INSTALL_PREFIX=../_install \
-      #      -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc
+      #      -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
       #    cmake --build build --target install
       - name: Google Test
         shell: bash
@@ -700,7 +700,7 @@ jobs:
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -GNinja \
             -DCMAKE_INSTALL_PREFIX=../_install \
-            -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc
+            -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
           cmake --build build --target install
       - name: zlib
         shell: bash
@@ -713,7 +713,7 @@ jobs:
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -GNinja \
             -DCMAKE_INSTALL_PREFIX=../_install \
-            -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc
+            -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
           cmake --build build --target install
 
       # sin-cpp
@@ -726,7 +726,7 @@ jobs:
           -G"`python3 -c "import random; print(random.choice(['Ninja', 'Unix Makefiles']))"`" \
           -DCMAKE_INSTALL_PREFIX=../_install \
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-          -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc
+          -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
       - name: Build
         shell: bash
         run: |
@@ -809,7 +809,7 @@ jobs:
       #      -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
       #      -GNinja \
       #      -DCMAKE_INSTALL_PREFIX=../_install \
-      #      -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
+      #      -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
       #    cmake --build build --target install
       - name: Google Test
         shell: bash
@@ -823,7 +823,7 @@ jobs:
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -GNinja \
             -DCMAKE_INSTALL_PREFIX=../_install \
-            -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
+            -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
           cmake --build build --target install
       - name: zlib
         shell: bash
@@ -836,7 +836,7 @@ jobs:
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -GNinja \
             -DCMAKE_INSTALL_PREFIX=../_install \
-            -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
+            -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
           cmake --build build --target install
 
       # sin-cpp
@@ -849,7 +849,7 @@ jobs:
           -G"`python3 -c "import random; print(random.choice(['Ninja', 'Unix Makefiles']))"`" \
           -DCMAKE_INSTALL_PREFIX=../_install \
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-          -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
+          -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
       - name: Build
         shell: bash
         run: |
@@ -930,7 +930,7 @@ jobs:
       #      -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
       #      -GNinja \
       #      -DCMAKE_INSTALL_PREFIX=../_install \
-      #      -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc
+      #      -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
       #    cmake --build build --target install
       - name: Google Test
         shell: bash
@@ -944,7 +944,7 @@ jobs:
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -GNinja \
             -DCMAKE_INSTALL_PREFIX=../_install \
-            -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc
+            -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
           cmake --build build --target install
       - name: zlib
         shell: bash
@@ -957,7 +957,7 @@ jobs:
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -GNinja \
             -DCMAKE_INSTALL_PREFIX=../_install \
-            -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc
+            -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
           cmake --build build --target install
 
       # sin-cpp
@@ -970,7 +970,7 @@ jobs:
           -G"`python3 -c "import random; print(random.choice(['Ninja', 'Unix Makefiles']))"`" \
           -DCMAKE_INSTALL_PREFIX=../_install \
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-          -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc
+          -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
       - name: Build
         shell: bash
         run: |
@@ -1053,7 +1053,7 @@ jobs:
       #      -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
       #      -GNinja \
       #      -DCMAKE_INSTALL_PREFIX=../_install \
-      #      -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
+      #      -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
       #    cmake --build build --target install
       - name: Google Test
         shell: bash
@@ -1067,7 +1067,7 @@ jobs:
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -GNinja \
             -DCMAKE_INSTALL_PREFIX=../_install \
-            -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
+            -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
           cmake --build build --target install
       - name: zlib
         shell: bash
@@ -1080,7 +1080,7 @@ jobs:
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -GNinja \
             -DCMAKE_INSTALL_PREFIX=../_install \
-            -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
+            -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
           cmake --build build --target install
 
       # sin-cpp
@@ -1093,7 +1093,7 @@ jobs:
           -G"`python3 -c "import random; print(random.choice(['Ninja', 'Unix Makefiles']))"`" \
           -DCMAKE_INSTALL_PREFIX=../_install \
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-          -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
+          -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
       - name: Build
         shell: bash
         run: |
@@ -1174,7 +1174,7 @@ jobs:
       #      -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
       #      -GNinja \
       #      -DCMAKE_INSTALL_PREFIX=../_install \
-      #      -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc
+      #      -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
       #    cmake --build build --target install
       - name: Google Test
         shell: bash
@@ -1188,7 +1188,7 @@ jobs:
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -GNinja \
             -DCMAKE_INSTALL_PREFIX=../_install \
-            -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc
+            -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
           cmake --build build --target install
       - name: zlib
         shell: bash
@@ -1201,7 +1201,7 @@ jobs:
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -GNinja \
             -DCMAKE_INSTALL_PREFIX=../_install \
-            -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc
+            -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
           cmake --build build --target install
 
       # sin-cpp
@@ -1214,7 +1214,7 @@ jobs:
           -G"`python3 -c "import random; print(random.choice(['Ninja', 'Unix Makefiles']))"`" \
           -DCMAKE_INSTALL_PREFIX=../_install \
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-          -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc
+          -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
       - name: Build
         shell: bash
         run: |
@@ -1297,7 +1297,7 @@ jobs:
       #      -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
       #      -GNinja \
       #      -DCMAKE_INSTALL_PREFIX=../_install \
-      #      -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
+      #      -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
       #    cmake --build build --target install
       - name: Google Test
         shell: bash
@@ -1311,7 +1311,7 @@ jobs:
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -GNinja \
             -DCMAKE_INSTALL_PREFIX=../_install \
-            -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
+            -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
           cmake --build build --target install
       - name: zlib
         shell: bash
@@ -1324,7 +1324,7 @@ jobs:
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -GNinja \
             -DCMAKE_INSTALL_PREFIX=../_install \
-            -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
+            -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
           cmake --build build --target install
 
       # sin-cpp
@@ -1337,7 +1337,7 @@ jobs:
           -G"`python3 -c "import random; print(random.choice(['Ninja', 'Unix Makefiles']))"`" \
           -DCMAKE_INSTALL_PREFIX=../_install \
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-          -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
+          -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
       - name: Build
         shell: bash
         run: |
@@ -1418,7 +1418,7 @@ jobs:
       #      -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
       #      -GNinja \
       #      -DCMAKE_INSTALL_PREFIX=../_install \
-      #      -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc
+      #      -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
       #    cmake --build build --target install
       - name: Google Test
         shell: bash
@@ -1432,7 +1432,7 @@ jobs:
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -GNinja \
             -DCMAKE_INSTALL_PREFIX=../_install \
-            -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc
+            -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
           cmake --build build --target install
       - name: zlib
         shell: bash
@@ -1445,7 +1445,7 @@ jobs:
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -GNinja \
             -DCMAKE_INSTALL_PREFIX=../_install \
-            -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc
+            -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
           cmake --build build --target install
 
       # sin-cpp
@@ -1458,7 +1458,7 @@ jobs:
           -G"`python3 -c "import random; print(random.choice(['Ninja', 'Unix Makefiles']))"`" \
           -DCMAKE_INSTALL_PREFIX=../_install \
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-          -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc
+          -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
       - name: Build
         shell: bash
         run: |
@@ -1541,7 +1541,7 @@ jobs:
       #      -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
       #      -GNinja \
       #      -DCMAKE_INSTALL_PREFIX=../_install \
-      #      -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
+      #      -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
       #    cmake --build build --target install
       - name: Google Test
         shell: bash
@@ -1555,7 +1555,7 @@ jobs:
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -GNinja \
             -DCMAKE_INSTALL_PREFIX=../_install \
-            -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
+            -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
           cmake --build build --target install
       - name: zlib
         shell: bash
@@ -1568,7 +1568,7 @@ jobs:
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -GNinja \
             -DCMAKE_INSTALL_PREFIX=../_install \
-            -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
+            -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
           cmake --build build --target install
 
       # sin-cpp
@@ -1581,7 +1581,7 @@ jobs:
           -G"`python3 -c "import random; print(random.choice(['Ninja', 'Unix Makefiles']))"`" \
           -DCMAKE_INSTALL_PREFIX=../_install \
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-          -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
+          -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
       - name: Build
         shell: bash
         run: |
@@ -1662,7 +1662,7 @@ jobs:
       #      -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
       #      -GNinja \
       #      -DCMAKE_INSTALL_PREFIX=../_install \
-      #      -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc
+      #      -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
       #    cmake --build build --target install
       - name: Google Test
         shell: bash
@@ -1676,7 +1676,7 @@ jobs:
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -GNinja \
             -DCMAKE_INSTALL_PREFIX=../_install \
-            -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc
+            -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
           cmake --build build --target install
       - name: zlib
         shell: bash
@@ -1689,7 +1689,7 @@ jobs:
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -GNinja \
             -DCMAKE_INSTALL_PREFIX=../_install \
-            -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc
+            -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
           cmake --build build --target install
 
       # sin-cpp
@@ -1702,7 +1702,7 @@ jobs:
           -G"`python3 -c "import random; print(random.choice(['Ninja', 'Unix Makefiles']))"`" \
           -DCMAKE_INSTALL_PREFIX=../_install \
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-          -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc
+          -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
       - name: Build
         shell: bash
         run: |
@@ -1785,7 +1785,7 @@ jobs:
       #      -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
       #      -GNinja \
       #      -DCMAKE_INSTALL_PREFIX=../_install \
-      #      -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
+      #      -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
       #    cmake --build build --target install
       - name: Google Test
         shell: bash
@@ -1799,7 +1799,7 @@ jobs:
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -GNinja \
             -DCMAKE_INSTALL_PREFIX=../_install \
-            -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
+            -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
           cmake --build build --target install
       - name: zlib
         shell: bash
@@ -1812,7 +1812,7 @@ jobs:
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -GNinja \
             -DCMAKE_INSTALL_PREFIX=../_install \
-            -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
+            -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
           cmake --build build --target install
 
       # sin-cpp
@@ -1825,7 +1825,7 @@ jobs:
           -G"`python3 -c "import random; print(random.choice(['Ninja', 'Unix Makefiles']))"`" \
           -DCMAKE_INSTALL_PREFIX=../_install \
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-          -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
+          -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
       - name: Build
         shell: bash
         run: |
@@ -1906,7 +1906,7 @@ jobs:
       #      -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
       #      -GNinja \
       #      -DCMAKE_INSTALL_PREFIX=../_install \
-      #      -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc
+      #      -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
       #    cmake --build build --target install
       - name: Google Test
         shell: bash
@@ -1920,7 +1920,7 @@ jobs:
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -GNinja \
             -DCMAKE_INSTALL_PREFIX=../_install \
-            -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc
+            -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
           cmake --build build --target install
       - name: zlib
         shell: bash
@@ -1933,7 +1933,7 @@ jobs:
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -GNinja \
             -DCMAKE_INSTALL_PREFIX=../_install \
-            -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc
+            -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
           cmake --build build --target install
 
       # sin-cpp
@@ -1946,7 +1946,7 @@ jobs:
           -G"`python3 -c "import random; print(random.choice(['Ninja', 'Unix Makefiles']))"`" \
           -DCMAKE_INSTALL_PREFIX=../_install \
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-          -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc
+          -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
       - name: Build
         shell: bash
         run: |
@@ -2029,7 +2029,7 @@ jobs:
       #      -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
       #      -GNinja \
       #      -DCMAKE_INSTALL_PREFIX=../_install \
-      #      -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
+      #      -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
       #    cmake --build build --target install
       - name: Google Test
         shell: bash
@@ -2043,7 +2043,7 @@ jobs:
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -GNinja \
             -DCMAKE_INSTALL_PREFIX=../_install \
-            -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
+            -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
           cmake --build build --target install
       - name: zlib
         shell: bash
@@ -2056,7 +2056,7 @@ jobs:
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -GNinja \
             -DCMAKE_INSTALL_PREFIX=../_install \
-            -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
+            -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
           cmake --build build --target install
 
       # sin-cpp
@@ -2069,7 +2069,7 @@ jobs:
           -G"`python3 -c "import random; print(random.choice(['Ninja', 'Unix Makefiles']))"`" \
           -DCMAKE_INSTALL_PREFIX=../_install \
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-          -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
+          -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
       - name: Build
         shell: bash
         run: |
@@ -2150,7 +2150,7 @@ jobs:
       #      -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
       #      -GNinja \
       #      -DCMAKE_INSTALL_PREFIX=../_install \
-      #      -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc
+      #      -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
       #    cmake --build build --target install
       - name: Google Test
         shell: bash
@@ -2164,7 +2164,7 @@ jobs:
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -GNinja \
             -DCMAKE_INSTALL_PREFIX=../_install \
-            -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc
+            -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
           cmake --build build --target install
       - name: zlib
         shell: bash
@@ -2177,7 +2177,7 @@ jobs:
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -GNinja \
             -DCMAKE_INSTALL_PREFIX=../_install \
-            -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc
+            -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
           cmake --build build --target install
 
       # sin-cpp
@@ -2190,7 +2190,7 @@ jobs:
           -G"`python3 -c "import random; print(random.choice(['Ninja', 'Unix Makefiles']))"`" \
           -DCMAKE_INSTALL_PREFIX=../_install \
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-          -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc
+          -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
       - name: Build
         shell: bash
         run: |
@@ -2273,7 +2273,7 @@ jobs:
       #      -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
       #      -GNinja \
       #      -DCMAKE_INSTALL_PREFIX=../_install \
-      #      -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
+      #      -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
       #    cmake --build build --target install
       - name: Google Test
         shell: bash
@@ -2287,7 +2287,7 @@ jobs:
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -GNinja \
             -DCMAKE_INSTALL_PREFIX=../_install \
-            -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
+            -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
           cmake --build build --target install
       - name: zlib
         shell: bash
@@ -2300,7 +2300,7 @@ jobs:
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -GNinja \
             -DCMAKE_INSTALL_PREFIX=../_install \
-            -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
+            -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
           cmake --build build --target install
 
       # sin-cpp
@@ -2313,7 +2313,7 @@ jobs:
           -G"`python3 -c "import random; print(random.choice(['Ninja', 'Unix Makefiles']))"`" \
           -DCMAKE_INSTALL_PREFIX=../_install \
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-          -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
+          -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
       - name: Build
         shell: bash
         run: |
@@ -2394,7 +2394,7 @@ jobs:
       #      -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
       #      -GNinja \
       #      -DCMAKE_INSTALL_PREFIX=../_install \
-      #      -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc
+      #      -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
       #    cmake --build build --target install
       - name: Google Test
         shell: bash
@@ -2408,7 +2408,7 @@ jobs:
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -GNinja \
             -DCMAKE_INSTALL_PREFIX=../_install \
-            -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc
+            -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
           cmake --build build --target install
       - name: zlib
         shell: bash
@@ -2421,7 +2421,7 @@ jobs:
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -GNinja \
             -DCMAKE_INSTALL_PREFIX=../_install \
-            -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc
+            -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
           cmake --build build --target install
 
       # sin-cpp
@@ -2434,7 +2434,1227 @@ jobs:
           -G"`python3 -c "import random; print(random.choice(['Ninja', 'Unix Makefiles']))"`" \
           -DCMAKE_INSTALL_PREFIX=../_install \
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-          -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc
+          -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
+      - name: Build
+        shell: bash
+        run: |
+          cd "$HOME/_ci_sin-cpp/sin-cpp/build"
+          VERBOSE=1 PATH="../_install/bin:$PATH" cmake --version
+          VERBOSE=1 PATH="../_install/bin:$PATH" cmake --build .
+      - name: Tests
+        shell: bash
+        run: |
+          cd "$HOME/_ci_sin-cpp/sin-cpp/build"
+          VERBOSE=1 PATH="../_install/bin:$PATH" ctest --output-on-failure
+
+  # debian14-amd64
+
+  debian14-amd64-clang:
+    continue-on-error: true
+    timeout-minutes: 600
+    runs-on: [ self-hosted, debian14-amd64 ]
+    name: debian14-amd64-clang
+    steps:
+
+      # Clean
+      - name: Clean
+        run: |
+          rm -rf "$HOME/_ci_sin-cpp"
+          mkdir -p "$HOME/_ci_sin-cpp"
+
+      # Clone
+      - name: Clone Google Benchmark
+        uses: actions/checkout@v4
+        with:
+          repository: "google/benchmark"
+          path: 'benchmark'
+          fetch-depth: 1
+      - name: Clone Google Test
+        uses: actions/checkout@v4
+        with:
+          repository: "google/googletest"
+          path: 'googletest'
+          fetch-depth: 1
+      - name: Clone zlib
+        uses: actions/checkout@v4
+        with:
+          repository: "madler/zlib"
+          path: 'zlib'
+          fetch-depth: 1
+      - name: Clone sin-python
+        uses: actions/checkout@v4
+        with:
+          repository: 'sin-is-nsimd/sin-python'
+          path: 'sin-python'
+          fetch-depth: 1
+      - name: Clone sin-cmake
+        uses: actions/checkout@v4
+        with:
+          repository: 'sin-is-nsimd/sin-cmake'
+          path: 'sin-cmake'
+          fetch-depth: 1
+      - name: Clone sin-cpp
+        uses: actions/checkout@v4
+        with:
+          repository: 'sin-is-nsimd/sin-cpp'
+          path: 'sin-cpp'
+          fetch-depth: 1
+
+      # Move Repositories
+      - name: Move Repositories
+        run: cp -r * "$HOME/_ci_sin-cpp"
+
+      # Dependencies
+      #- name: Google Benchmark
+      #  shell: bash
+      #  run: |
+      #    cd "$HOME/_ci_sin-cpp/benchmark"
+      #    cmake \
+      #      -B build \
+      #      -DBENCHMARK_ENABLE_TESTING=OFF \
+      #      -DBENCHMARK_ENABLE_GTEST_TESTS=OFF \
+      #      -DCMAKE_BUILD_TYPE=Release \
+      #      -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+      #      -GNinja \
+      #      -DCMAKE_INSTALL_PREFIX=../_install \
+      #      -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
+      #    cmake --build build --target install
+      - name: Google Test
+        shell: bash
+        run: |
+          cd "$HOME/_ci_sin-cpp/googletest"
+          cmake \
+            -B build \
+            -DBUILD_GMOCK=OFF \
+            -Dgtest_build_tests=OFF -Dgtest_build_samples=OFF \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -GNinja \
+            -DCMAKE_INSTALL_PREFIX=../_install \
+            -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
+          cmake --build build --target install
+      - name: zlib
+        shell: bash
+        run: |
+          cd "$HOME/_ci_sin-cpp/zlib"
+          cmake \
+            -B build \
+            -DZLIB_BUILD_TESTING=OFF \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -GNinja \
+            -DCMAKE_INSTALL_PREFIX=../_install \
+            -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
+          cmake --build build --target install
+
+      # sin-cpp
+      - name: CMake
+        shell: bash
+        run: |
+          cd "$HOME/_ci_sin-cpp/sin-cpp"
+          VERBOSE=1 PATH="../_install/bin:$PATH" cmake --version
+          VERBOSE=1 PATH="../_install/bin:$PATH" cmake -B build -DCMAKE_BUILD_TYPE=Release \
+          -G"`python3 -c "import random; print(random.choice(['Ninja', 'Unix Makefiles']))"`" \
+          -DCMAKE_INSTALL_PREFIX=../_install \
+          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+          -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
+      - name: Build
+        shell: bash
+        run: |
+          cd "$HOME/_ci_sin-cpp/sin-cpp/build"
+          VERBOSE=1 PATH="../_install/bin:$PATH" cmake --version
+          VERBOSE=1 PATH="../_install/bin:$PATH" cmake --build .
+      - name: Tests
+        shell: bash
+        run: |
+          cd "$HOME/_ci_sin-cpp/sin-cpp/build"
+          VERBOSE=1 PATH="../_install/bin:$PATH" ctest --output-on-failure
+
+  debian14-amd64-gcc:
+    continue-on-error: true
+    timeout-minutes: 600
+    runs-on: [ self-hosted, debian14-amd64 ]
+    name: debian14-amd64-gcc
+    steps:
+
+      # Clean
+      - name: Clean
+        run: |
+          rm -rf "$HOME/_ci_sin-cpp"
+          mkdir -p "$HOME/_ci_sin-cpp"
+
+      # Clone
+      - name: Clone Google Benchmark
+        uses: actions/checkout@v4
+        with:
+          repository: "google/benchmark"
+          path: 'benchmark'
+          fetch-depth: 1
+      - name: Clone Google Test
+        uses: actions/checkout@v4
+        with:
+          repository: "google/googletest"
+          path: 'googletest'
+          fetch-depth: 1
+      - name: Clone zlib
+        uses: actions/checkout@v4
+        with:
+          repository: "madler/zlib"
+          path: 'zlib'
+          fetch-depth: 1
+      - name: Clone sin-python
+        uses: actions/checkout@v4
+        with:
+          repository: 'sin-is-nsimd/sin-python'
+          path: 'sin-python'
+          fetch-depth: 1
+      - name: Clone sin-cmake
+        uses: actions/checkout@v4
+        with:
+          repository: 'sin-is-nsimd/sin-cmake'
+          path: 'sin-cmake'
+          fetch-depth: 1
+      - name: Clone sin-cpp
+        uses: actions/checkout@v4
+        with:
+          repository: 'sin-is-nsimd/sin-cpp'
+          path: 'sin-cpp'
+          fetch-depth: 1
+
+      # Move Repositories
+      - name: Move Repositories
+        run: cp -r * "$HOME/_ci_sin-cpp"
+
+      # Dependencies
+      #- name: Google Benchmark
+      #  shell: bash
+      #  run: |
+      #    cd "$HOME/_ci_sin-cpp/benchmark"
+      #    cmake \
+      #      -B build \
+      #      -DBENCHMARK_ENABLE_TESTING=OFF \
+      #      -DBENCHMARK_ENABLE_GTEST_TESTS=OFF \
+      #      -DCMAKE_BUILD_TYPE=Release \
+      #      -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+      #      -GNinja \
+      #      -DCMAKE_INSTALL_PREFIX=../_install \
+      #      -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
+      #    cmake --build build --target install
+      - name: Google Test
+        shell: bash
+        run: |
+          cd "$HOME/_ci_sin-cpp/googletest"
+          cmake \
+            -B build \
+            -DBUILD_GMOCK=OFF \
+            -Dgtest_build_tests=OFF -Dgtest_build_samples=OFF \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -GNinja \
+            -DCMAKE_INSTALL_PREFIX=../_install \
+            -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
+          cmake --build build --target install
+      - name: zlib
+        shell: bash
+        run: |
+          cd "$HOME/_ci_sin-cpp/zlib"
+          cmake \
+            -B build \
+            -DZLIB_BUILD_TESTING=OFF \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -GNinja \
+            -DCMAKE_INSTALL_PREFIX=../_install \
+            -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
+          cmake --build build --target install
+
+      # sin-cpp
+      - name: CMake
+        shell: bash
+        run: |
+          cd "$HOME/_ci_sin-cpp/sin-cpp"
+          VERBOSE=1 PATH="../_install/bin:$PATH" cmake --version
+          VERBOSE=1 PATH="../_install/bin:$PATH" cmake -B build -DCMAKE_BUILD_TYPE=Release \
+          -G"`python3 -c "import random; print(random.choice(['Ninja', 'Unix Makefiles']))"`" \
+          -DCMAKE_INSTALL_PREFIX=../_install \
+          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+          -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
+      - name: Build
+        shell: bash
+        run: |
+          cd "$HOME/_ci_sin-cpp/sin-cpp/build"
+          VERBOSE=1 PATH="../_install/bin:$PATH" cmake --version
+          VERBOSE=1 PATH="../_install/bin:$PATH" cmake --build .
+      - name: Tests
+        shell: bash
+        run: |
+          cd "$HOME/_ci_sin-cpp/sin-cpp/build"
+          VERBOSE=1 PATH="../_install/bin:$PATH" ctest --output-on-failure
+
+  # debian14-i386
+
+  debian14-i386-clang:
+    continue-on-error: true
+    timeout-minutes: 600
+    runs-on: [ self-hosted, debian14-i386 ]
+    name: debian14-i386-clang
+    steps:
+
+      # Clean
+      - name: Clean
+        run: |
+          rm -rf "$HOME/_ci_sin-cpp"
+          mkdir -p "$HOME/_ci_sin-cpp"
+
+      # Clone
+      - name: Clone Google Benchmark
+        uses: actions/checkout@v4
+        with:
+          repository: "google/benchmark"
+          path: 'benchmark'
+          fetch-depth: 1
+      - name: Clone Google Test
+        uses: actions/checkout@v4
+        with:
+          repository: "google/googletest"
+          path: 'googletest'
+          fetch-depth: 1
+      - name: Clone zlib
+        uses: actions/checkout@v4
+        with:
+          repository: "madler/zlib"
+          path: 'zlib'
+          fetch-depth: 1
+      - name: Clone sin-python
+        uses: actions/checkout@v4
+        with:
+          repository: 'sin-is-nsimd/sin-python'
+          path: 'sin-python'
+          fetch-depth: 1
+      - name: Clone sin-cmake
+        uses: actions/checkout@v4
+        with:
+          repository: 'sin-is-nsimd/sin-cmake'
+          path: 'sin-cmake'
+          fetch-depth: 1
+      - name: Clone sin-cpp
+        uses: actions/checkout@v4
+        with:
+          repository: 'sin-is-nsimd/sin-cpp'
+          path: 'sin-cpp'
+          fetch-depth: 1
+
+      # Move Repositories
+      - name: Move Repositories
+        run: cp -r * "$HOME/_ci_sin-cpp"
+
+      # Dependencies
+      #- name: Google Benchmark
+      #  shell: bash
+      #  run: |
+      #    cd "$HOME/_ci_sin-cpp/benchmark"
+      #    cmake \
+      #      -B build \
+      #      -DBENCHMARK_ENABLE_TESTING=OFF \
+      #      -DBENCHMARK_ENABLE_GTEST_TESTS=OFF \
+      #      -DCMAKE_BUILD_TYPE=Release \
+      #      -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+      #      -GNinja \
+      #      -DCMAKE_INSTALL_PREFIX=../_install \
+      #      -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
+      #    cmake --build build --target install
+      - name: Google Test
+        shell: bash
+        run: |
+          cd "$HOME/_ci_sin-cpp/googletest"
+          cmake \
+            -B build \
+            -DBUILD_GMOCK=OFF \
+            -Dgtest_build_tests=OFF -Dgtest_build_samples=OFF \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -GNinja \
+            -DCMAKE_INSTALL_PREFIX=../_install \
+            -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
+          cmake --build build --target install
+      - name: zlib
+        shell: bash
+        run: |
+          cd "$HOME/_ci_sin-cpp/zlib"
+          cmake \
+            -B build \
+            -DZLIB_BUILD_TESTING=OFF \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -GNinja \
+            -DCMAKE_INSTALL_PREFIX=../_install \
+            -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
+          cmake --build build --target install
+
+      # sin-cpp
+      - name: CMake
+        shell: bash
+        run: |
+          cd "$HOME/_ci_sin-cpp/sin-cpp"
+          VERBOSE=1 PATH="../_install/bin:$PATH" cmake --version
+          VERBOSE=1 PATH="../_install/bin:$PATH" cmake -B build -DCMAKE_BUILD_TYPE=Release \
+          -G"`python3 -c "import random; print(random.choice(['Ninja', 'Unix Makefiles']))"`" \
+          -DCMAKE_INSTALL_PREFIX=../_install \
+          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+          -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
+      - name: Build
+        shell: bash
+        run: |
+          cd "$HOME/_ci_sin-cpp/sin-cpp/build"
+          VERBOSE=1 PATH="../_install/bin:$PATH" cmake --version
+          VERBOSE=1 PATH="../_install/bin:$PATH" cmake --build .
+      - name: Tests
+        shell: bash
+        run: |
+          cd "$HOME/_ci_sin-cpp/sin-cpp/build"
+          VERBOSE=1 PATH="../_install/bin:$PATH" ctest --output-on-failure
+
+  debian14-i386-gcc:
+    continue-on-error: true
+    timeout-minutes: 600
+    runs-on: [ self-hosted, debian14-i386 ]
+    name: debian14-i386-gcc
+    steps:
+
+      # Clean
+      - name: Clean
+        run: |
+          rm -rf "$HOME/_ci_sin-cpp"
+          mkdir -p "$HOME/_ci_sin-cpp"
+
+      # Clone
+      - name: Clone Google Benchmark
+        uses: actions/checkout@v4
+        with:
+          repository: "google/benchmark"
+          path: 'benchmark'
+          fetch-depth: 1
+      - name: Clone Google Test
+        uses: actions/checkout@v4
+        with:
+          repository: "google/googletest"
+          path: 'googletest'
+          fetch-depth: 1
+      - name: Clone zlib
+        uses: actions/checkout@v4
+        with:
+          repository: "madler/zlib"
+          path: 'zlib'
+          fetch-depth: 1
+      - name: Clone sin-python
+        uses: actions/checkout@v4
+        with:
+          repository: 'sin-is-nsimd/sin-python'
+          path: 'sin-python'
+          fetch-depth: 1
+      - name: Clone sin-cmake
+        uses: actions/checkout@v4
+        with:
+          repository: 'sin-is-nsimd/sin-cmake'
+          path: 'sin-cmake'
+          fetch-depth: 1
+      - name: Clone sin-cpp
+        uses: actions/checkout@v4
+        with:
+          repository: 'sin-is-nsimd/sin-cpp'
+          path: 'sin-cpp'
+          fetch-depth: 1
+
+      # Move Repositories
+      - name: Move Repositories
+        run: cp -r * "$HOME/_ci_sin-cpp"
+
+      # Dependencies
+      #- name: Google Benchmark
+      #  shell: bash
+      #  run: |
+      #    cd "$HOME/_ci_sin-cpp/benchmark"
+      #    cmake \
+      #      -B build \
+      #      -DBENCHMARK_ENABLE_TESTING=OFF \
+      #      -DBENCHMARK_ENABLE_GTEST_TESTS=OFF \
+      #      -DCMAKE_BUILD_TYPE=Release \
+      #      -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+      #      -GNinja \
+      #      -DCMAKE_INSTALL_PREFIX=../_install \
+      #      -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
+      #    cmake --build build --target install
+      - name: Google Test
+        shell: bash
+        run: |
+          cd "$HOME/_ci_sin-cpp/googletest"
+          cmake \
+            -B build \
+            -DBUILD_GMOCK=OFF \
+            -Dgtest_build_tests=OFF -Dgtest_build_samples=OFF \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -GNinja \
+            -DCMAKE_INSTALL_PREFIX=../_install \
+            -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
+          cmake --build build --target install
+      - name: zlib
+        shell: bash
+        run: |
+          cd "$HOME/_ci_sin-cpp/zlib"
+          cmake \
+            -B build \
+            -DZLIB_BUILD_TESTING=OFF \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -GNinja \
+            -DCMAKE_INSTALL_PREFIX=../_install \
+            -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
+          cmake --build build --target install
+
+      # sin-cpp
+      - name: CMake
+        shell: bash
+        run: |
+          cd "$HOME/_ci_sin-cpp/sin-cpp"
+          VERBOSE=1 PATH="../_install/bin:$PATH" cmake --version
+          VERBOSE=1 PATH="../_install/bin:$PATH" cmake -B build -DCMAKE_BUILD_TYPE=Release \
+          -G"`python3 -c "import random; print(random.choice(['Ninja', 'Unix Makefiles']))"`" \
+          -DCMAKE_INSTALL_PREFIX=../_install \
+          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+          -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
+      - name: Build
+        shell: bash
+        run: |
+          cd "$HOME/_ci_sin-cpp/sin-cpp/build"
+          VERBOSE=1 PATH="../_install/bin:$PATH" cmake --version
+          VERBOSE=1 PATH="../_install/bin:$PATH" cmake --build .
+      - name: Tests
+        shell: bash
+        run: |
+          cd "$HOME/_ci_sin-cpp/sin-cpp/build"
+          VERBOSE=1 PATH="../_install/bin:$PATH" ctest --output-on-failure
+
+  # debian14-armhf
+
+  debian14-armhf-clang:
+    continue-on-error: true
+    timeout-minutes: 600
+    runs-on: [ self-hosted, debian14-armhf ]
+    name: debian14-armhf-clang
+    steps:
+
+      # Clean
+      - name: Clean
+        run: |
+          rm -rf "$HOME/_ci_sin-cpp"
+          mkdir -p "$HOME/_ci_sin-cpp"
+
+      # Clone
+      - name: Clone Google Benchmark
+        uses: actions/checkout@v4
+        with:
+          repository: "google/benchmark"
+          path: 'benchmark'
+          fetch-depth: 1
+      - name: Clone Google Test
+        uses: actions/checkout@v4
+        with:
+          repository: "google/googletest"
+          path: 'googletest'
+          fetch-depth: 1
+      - name: Clone zlib
+        uses: actions/checkout@v4
+        with:
+          repository: "madler/zlib"
+          path: 'zlib'
+          fetch-depth: 1
+      - name: Clone sin-python
+        uses: actions/checkout@v4
+        with:
+          repository: 'sin-is-nsimd/sin-python'
+          path: 'sin-python'
+          fetch-depth: 1
+      - name: Clone sin-cmake
+        uses: actions/checkout@v4
+        with:
+          repository: 'sin-is-nsimd/sin-cmake'
+          path: 'sin-cmake'
+          fetch-depth: 1
+      - name: Clone sin-cpp
+        uses: actions/checkout@v4
+        with:
+          repository: 'sin-is-nsimd/sin-cpp'
+          path: 'sin-cpp'
+          fetch-depth: 1
+
+      # Move Repositories
+      - name: Move Repositories
+        run: cp -r * "$HOME/_ci_sin-cpp"
+
+      # Dependencies
+      #- name: Google Benchmark
+      #  shell: bash
+      #  run: |
+      #    cd "$HOME/_ci_sin-cpp/benchmark"
+      #    cmake \
+      #      -B build \
+      #      -DBENCHMARK_ENABLE_TESTING=OFF \
+      #      -DBENCHMARK_ENABLE_GTEST_TESTS=OFF \
+      #      -DCMAKE_BUILD_TYPE=Release \
+      #      -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+      #      -GNinja \
+      #      -DCMAKE_INSTALL_PREFIX=../_install \
+      #      -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
+      #    cmake --build build --target install
+      - name: Google Test
+        shell: bash
+        run: |
+          cd "$HOME/_ci_sin-cpp/googletest"
+          cmake \
+            -B build \
+            -DBUILD_GMOCK=OFF \
+            -Dgtest_build_tests=OFF -Dgtest_build_samples=OFF \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -GNinja \
+            -DCMAKE_INSTALL_PREFIX=../_install \
+            -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
+          cmake --build build --target install
+      - name: zlib
+        shell: bash
+        run: |
+          cd "$HOME/_ci_sin-cpp/zlib"
+          cmake \
+            -B build \
+            -DZLIB_BUILD_TESTING=OFF \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -GNinja \
+            -DCMAKE_INSTALL_PREFIX=../_install \
+            -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
+          cmake --build build --target install
+
+      # sin-cpp
+      - name: CMake
+        shell: bash
+        run: |
+          cd "$HOME/_ci_sin-cpp/sin-cpp"
+          VERBOSE=1 PATH="../_install/bin:$PATH" cmake --version
+          VERBOSE=1 PATH="../_install/bin:$PATH" cmake -B build -DCMAKE_BUILD_TYPE=Release \
+          -G"`python3 -c "import random; print(random.choice(['Ninja', 'Unix Makefiles']))"`" \
+          -DCMAKE_INSTALL_PREFIX=../_install \
+          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+          -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
+      - name: Build
+        shell: bash
+        run: |
+          cd "$HOME/_ci_sin-cpp/sin-cpp/build"
+          VERBOSE=1 PATH="../_install/bin:$PATH" cmake --version
+          VERBOSE=1 PATH="../_install/bin:$PATH" cmake --build .
+      - name: Tests
+        shell: bash
+        run: |
+          cd "$HOME/_ci_sin-cpp/sin-cpp/build"
+          VERBOSE=1 PATH="../_install/bin:$PATH" ctest --output-on-failure
+
+  debian14-armhf-gcc:
+    continue-on-error: true
+    timeout-minutes: 600
+    runs-on: [ self-hosted, debian14-armhf ]
+    name: debian14-armhf-gcc
+    steps:
+
+      # Clean
+      - name: Clean
+        run: |
+          rm -rf "$HOME/_ci_sin-cpp"
+          mkdir -p "$HOME/_ci_sin-cpp"
+
+      # Clone
+      - name: Clone Google Benchmark
+        uses: actions/checkout@v4
+        with:
+          repository: "google/benchmark"
+          path: 'benchmark'
+          fetch-depth: 1
+      - name: Clone Google Test
+        uses: actions/checkout@v4
+        with:
+          repository: "google/googletest"
+          path: 'googletest'
+          fetch-depth: 1
+      - name: Clone zlib
+        uses: actions/checkout@v4
+        with:
+          repository: "madler/zlib"
+          path: 'zlib'
+          fetch-depth: 1
+      - name: Clone sin-python
+        uses: actions/checkout@v4
+        with:
+          repository: 'sin-is-nsimd/sin-python'
+          path: 'sin-python'
+          fetch-depth: 1
+      - name: Clone sin-cmake
+        uses: actions/checkout@v4
+        with:
+          repository: 'sin-is-nsimd/sin-cmake'
+          path: 'sin-cmake'
+          fetch-depth: 1
+      - name: Clone sin-cpp
+        uses: actions/checkout@v4
+        with:
+          repository: 'sin-is-nsimd/sin-cpp'
+          path: 'sin-cpp'
+          fetch-depth: 1
+
+      # Move Repositories
+      - name: Move Repositories
+        run: cp -r * "$HOME/_ci_sin-cpp"
+
+      # Dependencies
+      #- name: Google Benchmark
+      #  shell: bash
+      #  run: |
+      #    cd "$HOME/_ci_sin-cpp/benchmark"
+      #    cmake \
+      #      -B build \
+      #      -DBENCHMARK_ENABLE_TESTING=OFF \
+      #      -DBENCHMARK_ENABLE_GTEST_TESTS=OFF \
+      #      -DCMAKE_BUILD_TYPE=Release \
+      #      -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+      #      -GNinja \
+      #      -DCMAKE_INSTALL_PREFIX=../_install \
+      #      -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
+      #    cmake --build build --target install
+      - name: Google Test
+        shell: bash
+        run: |
+          cd "$HOME/_ci_sin-cpp/googletest"
+          cmake \
+            -B build \
+            -DBUILD_GMOCK=OFF \
+            -Dgtest_build_tests=OFF -Dgtest_build_samples=OFF \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -GNinja \
+            -DCMAKE_INSTALL_PREFIX=../_install \
+            -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
+          cmake --build build --target install
+      - name: zlib
+        shell: bash
+        run: |
+          cd "$HOME/_ci_sin-cpp/zlib"
+          cmake \
+            -B build \
+            -DZLIB_BUILD_TESTING=OFF \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -GNinja \
+            -DCMAKE_INSTALL_PREFIX=../_install \
+            -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
+          cmake --build build --target install
+
+      # sin-cpp
+      - name: CMake
+        shell: bash
+        run: |
+          cd "$HOME/_ci_sin-cpp/sin-cpp"
+          VERBOSE=1 PATH="../_install/bin:$PATH" cmake --version
+          VERBOSE=1 PATH="../_install/bin:$PATH" cmake -B build -DCMAKE_BUILD_TYPE=Release \
+          -G"`python3 -c "import random; print(random.choice(['Ninja', 'Unix Makefiles']))"`" \
+          -DCMAKE_INSTALL_PREFIX=../_install \
+          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+          -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
+      - name: Build
+        shell: bash
+        run: |
+          cd "$HOME/_ci_sin-cpp/sin-cpp/build"
+          VERBOSE=1 PATH="../_install/bin:$PATH" cmake --version
+          VERBOSE=1 PATH="../_install/bin:$PATH" cmake --build .
+      - name: Tests
+        shell: bash
+        run: |
+          cd "$HOME/_ci_sin-cpp/sin-cpp/build"
+          VERBOSE=1 PATH="../_install/bin:$PATH" ctest --output-on-failure
+
+  # debian14-arm64
+
+  debian14-arm64-clang:
+    continue-on-error: true
+    timeout-minutes: 600
+    runs-on: [ self-hosted, debian14-arm64 ]
+    name: debian14-arm64-clang
+    steps:
+
+      # Clean
+      - name: Clean
+        run: |
+          rm -rf "$HOME/_ci_sin-cpp"
+          mkdir -p "$HOME/_ci_sin-cpp"
+
+      # Clone
+      - name: Clone Google Benchmark
+        uses: actions/checkout@v4
+        with:
+          repository: "google/benchmark"
+          path: 'benchmark'
+          fetch-depth: 1
+      - name: Clone Google Test
+        uses: actions/checkout@v4
+        with:
+          repository: "google/googletest"
+          path: 'googletest'
+          fetch-depth: 1
+      - name: Clone zlib
+        uses: actions/checkout@v4
+        with:
+          repository: "madler/zlib"
+          path: 'zlib'
+          fetch-depth: 1
+      - name: Clone sin-python
+        uses: actions/checkout@v4
+        with:
+          repository: 'sin-is-nsimd/sin-python'
+          path: 'sin-python'
+          fetch-depth: 1
+      - name: Clone sin-cmake
+        uses: actions/checkout@v4
+        with:
+          repository: 'sin-is-nsimd/sin-cmake'
+          path: 'sin-cmake'
+          fetch-depth: 1
+      - name: Clone sin-cpp
+        uses: actions/checkout@v4
+        with:
+          repository: 'sin-is-nsimd/sin-cpp'
+          path: 'sin-cpp'
+          fetch-depth: 1
+
+      # Move Repositories
+      - name: Move Repositories
+        run: cp -r * "$HOME/_ci_sin-cpp"
+
+      # Dependencies
+      #- name: Google Benchmark
+      #  shell: bash
+      #  run: |
+      #    cd "$HOME/_ci_sin-cpp/benchmark"
+      #    cmake \
+      #      -B build \
+      #      -DBENCHMARK_ENABLE_TESTING=OFF \
+      #      -DBENCHMARK_ENABLE_GTEST_TESTS=OFF \
+      #      -DCMAKE_BUILD_TYPE=Release \
+      #      -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+      #      -GNinja \
+      #      -DCMAKE_INSTALL_PREFIX=../_install \
+      #      -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
+      #    cmake --build build --target install
+      - name: Google Test
+        shell: bash
+        run: |
+          cd "$HOME/_ci_sin-cpp/googletest"
+          cmake \
+            -B build \
+            -DBUILD_GMOCK=OFF \
+            -Dgtest_build_tests=OFF -Dgtest_build_samples=OFF \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -GNinja \
+            -DCMAKE_INSTALL_PREFIX=../_install \
+            -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
+          cmake --build build --target install
+      - name: zlib
+        shell: bash
+        run: |
+          cd "$HOME/_ci_sin-cpp/zlib"
+          cmake \
+            -B build \
+            -DZLIB_BUILD_TESTING=OFF \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -GNinja \
+            -DCMAKE_INSTALL_PREFIX=../_install \
+            -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
+          cmake --build build --target install
+
+      # sin-cpp
+      - name: CMake
+        shell: bash
+        run: |
+          cd "$HOME/_ci_sin-cpp/sin-cpp"
+          VERBOSE=1 PATH="../_install/bin:$PATH" cmake --version
+          VERBOSE=1 PATH="../_install/bin:$PATH" cmake -B build -DCMAKE_BUILD_TYPE=Release \
+          -G"`python3 -c "import random; print(random.choice(['Ninja', 'Unix Makefiles']))"`" \
+          -DCMAKE_INSTALL_PREFIX=../_install \
+          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+          -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
+      - name: Build
+        shell: bash
+        run: |
+          cd "$HOME/_ci_sin-cpp/sin-cpp/build"
+          VERBOSE=1 PATH="../_install/bin:$PATH" cmake --version
+          VERBOSE=1 PATH="../_install/bin:$PATH" cmake --build .
+      - name: Tests
+        shell: bash
+        run: |
+          cd "$HOME/_ci_sin-cpp/sin-cpp/build"
+          VERBOSE=1 PATH="../_install/bin:$PATH" ctest --output-on-failure
+
+  debian14-arm64-gcc:
+    continue-on-error: true
+    timeout-minutes: 600
+    runs-on: [ self-hosted, debian14-arm64 ]
+    name: debian14-arm64-gcc
+    steps:
+
+      # Clean
+      - name: Clean
+        run: |
+          rm -rf "$HOME/_ci_sin-cpp"
+          mkdir -p "$HOME/_ci_sin-cpp"
+
+      # Clone
+      - name: Clone Google Benchmark
+        uses: actions/checkout@v4
+        with:
+          repository: "google/benchmark"
+          path: 'benchmark'
+          fetch-depth: 1
+      - name: Clone Google Test
+        uses: actions/checkout@v4
+        with:
+          repository: "google/googletest"
+          path: 'googletest'
+          fetch-depth: 1
+      - name: Clone zlib
+        uses: actions/checkout@v4
+        with:
+          repository: "madler/zlib"
+          path: 'zlib'
+          fetch-depth: 1
+      - name: Clone sin-python
+        uses: actions/checkout@v4
+        with:
+          repository: 'sin-is-nsimd/sin-python'
+          path: 'sin-python'
+          fetch-depth: 1
+      - name: Clone sin-cmake
+        uses: actions/checkout@v4
+        with:
+          repository: 'sin-is-nsimd/sin-cmake'
+          path: 'sin-cmake'
+          fetch-depth: 1
+      - name: Clone sin-cpp
+        uses: actions/checkout@v4
+        with:
+          repository: 'sin-is-nsimd/sin-cpp'
+          path: 'sin-cpp'
+          fetch-depth: 1
+
+      # Move Repositories
+      - name: Move Repositories
+        run: cp -r * "$HOME/_ci_sin-cpp"
+
+      # Dependencies
+      #- name: Google Benchmark
+      #  shell: bash
+      #  run: |
+      #    cd "$HOME/_ci_sin-cpp/benchmark"
+      #    cmake \
+      #      -B build \
+      #      -DBENCHMARK_ENABLE_TESTING=OFF \
+      #      -DBENCHMARK_ENABLE_GTEST_TESTS=OFF \
+      #      -DCMAKE_BUILD_TYPE=Release \
+      #      -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+      #      -GNinja \
+      #      -DCMAKE_INSTALL_PREFIX=../_install \
+      #      -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
+      #    cmake --build build --target install
+      - name: Google Test
+        shell: bash
+        run: |
+          cd "$HOME/_ci_sin-cpp/googletest"
+          cmake \
+            -B build \
+            -DBUILD_GMOCK=OFF \
+            -Dgtest_build_tests=OFF -Dgtest_build_samples=OFF \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -GNinja \
+            -DCMAKE_INSTALL_PREFIX=../_install \
+            -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
+          cmake --build build --target install
+      - name: zlib
+        shell: bash
+        run: |
+          cd "$HOME/_ci_sin-cpp/zlib"
+          cmake \
+            -B build \
+            -DZLIB_BUILD_TESTING=OFF \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -GNinja \
+            -DCMAKE_INSTALL_PREFIX=../_install \
+            -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
+          cmake --build build --target install
+
+      # sin-cpp
+      - name: CMake
+        shell: bash
+        run: |
+          cd "$HOME/_ci_sin-cpp/sin-cpp"
+          VERBOSE=1 PATH="../_install/bin:$PATH" cmake --version
+          VERBOSE=1 PATH="../_install/bin:$PATH" cmake -B build -DCMAKE_BUILD_TYPE=Release \
+          -G"`python3 -c "import random; print(random.choice(['Ninja', 'Unix Makefiles']))"`" \
+          -DCMAKE_INSTALL_PREFIX=../_install \
+          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+          -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
+      - name: Build
+        shell: bash
+        run: |
+          cd "$HOME/_ci_sin-cpp/sin-cpp/build"
+          VERBOSE=1 PATH="../_install/bin:$PATH" cmake --version
+          VERBOSE=1 PATH="../_install/bin:$PATH" cmake --build .
+      - name: Tests
+        shell: bash
+        run: |
+          cd "$HOME/_ci_sin-cpp/sin-cpp/build"
+          VERBOSE=1 PATH="../_install/bin:$PATH" ctest --output-on-failure
+
+  # debian14-ppc64el
+
+  debian14-ppc64el-clang:
+    continue-on-error: true
+    timeout-minutes: 600
+    runs-on: [ self-hosted, debian14-ppc64el ]
+    name: debian14-ppc64el-clang
+    steps:
+
+      # Clean
+      - name: Clean
+        run: |
+          rm -rf "$HOME/_ci_sin-cpp"
+          mkdir -p "$HOME/_ci_sin-cpp"
+
+      # Clone
+      - name: Clone Google Benchmark
+        uses: actions/checkout@v4
+        with:
+          repository: "google/benchmark"
+          path: 'benchmark'
+          fetch-depth: 1
+      - name: Clone Google Test
+        uses: actions/checkout@v4
+        with:
+          repository: "google/googletest"
+          path: 'googletest'
+          fetch-depth: 1
+      - name: Clone zlib
+        uses: actions/checkout@v4
+        with:
+          repository: "madler/zlib"
+          path: 'zlib'
+          fetch-depth: 1
+      - name: Clone sin-python
+        uses: actions/checkout@v4
+        with:
+          repository: 'sin-is-nsimd/sin-python'
+          path: 'sin-python'
+          fetch-depth: 1
+      - name: Clone sin-cmake
+        uses: actions/checkout@v4
+        with:
+          repository: 'sin-is-nsimd/sin-cmake'
+          path: 'sin-cmake'
+          fetch-depth: 1
+      - name: Clone sin-cpp
+        uses: actions/checkout@v4
+        with:
+          repository: 'sin-is-nsimd/sin-cpp'
+          path: 'sin-cpp'
+          fetch-depth: 1
+
+      # Move Repositories
+      - name: Move Repositories
+        run: cp -r * "$HOME/_ci_sin-cpp"
+
+      # Dependencies
+      #- name: Google Benchmark
+      #  shell: bash
+      #  run: |
+      #    cd "$HOME/_ci_sin-cpp/benchmark"
+      #    cmake \
+      #      -B build \
+      #      -DBENCHMARK_ENABLE_TESTING=OFF \
+      #      -DBENCHMARK_ENABLE_GTEST_TESTS=OFF \
+      #      -DCMAKE_BUILD_TYPE=Release \
+      #      -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+      #      -GNinja \
+      #      -DCMAKE_INSTALL_PREFIX=../_install \
+      #      -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
+      #    cmake --build build --target install
+      - name: Google Test
+        shell: bash
+        run: |
+          cd "$HOME/_ci_sin-cpp/googletest"
+          cmake \
+            -B build \
+            -DBUILD_GMOCK=OFF \
+            -Dgtest_build_tests=OFF -Dgtest_build_samples=OFF \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -GNinja \
+            -DCMAKE_INSTALL_PREFIX=../_install \
+            -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
+          cmake --build build --target install
+      - name: zlib
+        shell: bash
+        run: |
+          cd "$HOME/_ci_sin-cpp/zlib"
+          cmake \
+            -B build \
+            -DZLIB_BUILD_TESTING=OFF \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -GNinja \
+            -DCMAKE_INSTALL_PREFIX=../_install \
+            -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
+          cmake --build build --target install
+
+      # sin-cpp
+      - name: CMake
+        shell: bash
+        run: |
+          cd "$HOME/_ci_sin-cpp/sin-cpp"
+          VERBOSE=1 PATH="../_install/bin:$PATH" cmake --version
+          VERBOSE=1 PATH="../_install/bin:$PATH" cmake -B build -DCMAKE_BUILD_TYPE=Release \
+          -G"`python3 -c "import random; print(random.choice(['Ninja', 'Unix Makefiles']))"`" \
+          -DCMAKE_INSTALL_PREFIX=../_install \
+          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+          -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
+      - name: Build
+        shell: bash
+        run: |
+          cd "$HOME/_ci_sin-cpp/sin-cpp/build"
+          VERBOSE=1 PATH="../_install/bin:$PATH" cmake --version
+          VERBOSE=1 PATH="../_install/bin:$PATH" cmake --build .
+      - name: Tests
+        shell: bash
+        run: |
+          cd "$HOME/_ci_sin-cpp/sin-cpp/build"
+          VERBOSE=1 PATH="../_install/bin:$PATH" ctest --output-on-failure
+
+  debian14-ppc64el-gcc:
+    continue-on-error: true
+    timeout-minutes: 600
+    runs-on: [ self-hosted, debian14-ppc64el ]
+    name: debian14-ppc64el-gcc
+    steps:
+
+      # Clean
+      - name: Clean
+        run: |
+          rm -rf "$HOME/_ci_sin-cpp"
+          mkdir -p "$HOME/_ci_sin-cpp"
+
+      # Clone
+      - name: Clone Google Benchmark
+        uses: actions/checkout@v4
+        with:
+          repository: "google/benchmark"
+          path: 'benchmark'
+          fetch-depth: 1
+      - name: Clone Google Test
+        uses: actions/checkout@v4
+        with:
+          repository: "google/googletest"
+          path: 'googletest'
+          fetch-depth: 1
+      - name: Clone zlib
+        uses: actions/checkout@v4
+        with:
+          repository: "madler/zlib"
+          path: 'zlib'
+          fetch-depth: 1
+      - name: Clone sin-python
+        uses: actions/checkout@v4
+        with:
+          repository: 'sin-is-nsimd/sin-python'
+          path: 'sin-python'
+          fetch-depth: 1
+      - name: Clone sin-cmake
+        uses: actions/checkout@v4
+        with:
+          repository: 'sin-is-nsimd/sin-cmake'
+          path: 'sin-cmake'
+          fetch-depth: 1
+      - name: Clone sin-cpp
+        uses: actions/checkout@v4
+        with:
+          repository: 'sin-is-nsimd/sin-cpp'
+          path: 'sin-cpp'
+          fetch-depth: 1
+
+      # Move Repositories
+      - name: Move Repositories
+        run: cp -r * "$HOME/_ci_sin-cpp"
+
+      # Dependencies
+      #- name: Google Benchmark
+      #  shell: bash
+      #  run: |
+      #    cd "$HOME/_ci_sin-cpp/benchmark"
+      #    cmake \
+      #      -B build \
+      #      -DBENCHMARK_ENABLE_TESTING=OFF \
+      #      -DBENCHMARK_ENABLE_GTEST_TESTS=OFF \
+      #      -DCMAKE_BUILD_TYPE=Release \
+      #      -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+      #      -GNinja \
+      #      -DCMAKE_INSTALL_PREFIX=../_install \
+      #      -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
+      #    cmake --build build --target install
+      - name: Google Test
+        shell: bash
+        run: |
+          cd "$HOME/_ci_sin-cpp/googletest"
+          cmake \
+            -B build \
+            -DBUILD_GMOCK=OFF \
+            -Dgtest_build_tests=OFF -Dgtest_build_samples=OFF \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -GNinja \
+            -DCMAKE_INSTALL_PREFIX=../_install \
+            -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
+          cmake --build build --target install
+      - name: zlib
+        shell: bash
+        run: |
+          cd "$HOME/_ci_sin-cpp/zlib"
+          cmake \
+            -B build \
+            -DZLIB_BUILD_TESTING=OFF \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -GNinja \
+            -DCMAKE_INSTALL_PREFIX=../_install \
+            -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
+          cmake --build build --target install
+
+      # sin-cpp
+      - name: CMake
+        shell: bash
+        run: |
+          cd "$HOME/_ci_sin-cpp/sin-cpp"
+          VERBOSE=1 PATH="../_install/bin:$PATH" cmake --version
+          VERBOSE=1 PATH="../_install/bin:$PATH" cmake -B build -DCMAKE_BUILD_TYPE=Release \
+          -G"`python3 -c "import random; print(random.choice(['Ninja', 'Unix Makefiles']))"`" \
+          -DCMAKE_INSTALL_PREFIX=../_install \
+          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+          -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
       - name: Build
         shell: bash
         run: |
@@ -2517,7 +3737,7 @@ jobs:
       #      -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
       #      -GNinja \
       #      -DCMAKE_INSTALL_PREFIX=../_install \
-      #      -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
+      #      -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_FLAGS="-mcpu=arm1176jzf-s -mfpu=vfp -mfloat-abi=hard" -DCMAKE_CXX_FLAGS="-mcpu=arm1176jzf-s -mfpu=vfp -mfloat-abi=hard"
       #    cmake --build build --target install
       - name: Google Test
         shell: bash
@@ -2531,7 +3751,7 @@ jobs:
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -GNinja \
             -DCMAKE_INSTALL_PREFIX=../_install \
-            -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
+            -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_FLAGS="-mcpu=arm1176jzf-s -mfpu=vfp -mfloat-abi=hard" -DCMAKE_CXX_FLAGS="-mcpu=arm1176jzf-s -mfpu=vfp -mfloat-abi=hard"
           cmake --build build --target install
       - name: zlib
         shell: bash
@@ -2544,7 +3764,7 @@ jobs:
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -GNinja \
             -DCMAKE_INSTALL_PREFIX=../_install \
-            -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
+            -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_FLAGS="-mcpu=arm1176jzf-s -mfpu=vfp -mfloat-abi=hard" -DCMAKE_CXX_FLAGS="-mcpu=arm1176jzf-s -mfpu=vfp -mfloat-abi=hard"
           cmake --build build --target install
 
       # sin-cpp
@@ -2557,7 +3777,7 @@ jobs:
           -G"`python3 -c "import random; print(random.choice(['Ninja', 'Unix Makefiles']))"`" \
           -DCMAKE_INSTALL_PREFIX=../_install \
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-          -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
+          -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_FLAGS="-mcpu=arm1176jzf-s -mfpu=vfp -mfloat-abi=hard" -DCMAKE_CXX_FLAGS="-mcpu=arm1176jzf-s -mfpu=vfp -mfloat-abi=hard"
       - name: Build
         shell: bash
         run: |
@@ -2638,7 +3858,7 @@ jobs:
       #      -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
       #      -GNinja \
       #      -DCMAKE_INSTALL_PREFIX=../_install \
-      #      -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc
+      #      -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_FLAGS="-mcpu=arm1176jzf-s -mfpu=vfp -mfloat-abi=hard" -DCMAKE_CXX_FLAGS="-mcpu=arm1176jzf-s -mfpu=vfp -mfloat-abi=hard"
       #    cmake --build build --target install
       - name: Google Test
         shell: bash
@@ -2652,7 +3872,7 @@ jobs:
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -GNinja \
             -DCMAKE_INSTALL_PREFIX=../_install \
-            -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc
+            -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_FLAGS="-mcpu=arm1176jzf-s -mfpu=vfp -mfloat-abi=hard" -DCMAKE_CXX_FLAGS="-mcpu=arm1176jzf-s -mfpu=vfp -mfloat-abi=hard"
           cmake --build build --target install
       - name: zlib
         shell: bash
@@ -2665,7 +3885,7 @@ jobs:
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -GNinja \
             -DCMAKE_INSTALL_PREFIX=../_install \
-            -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc
+            -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_FLAGS="-mcpu=arm1176jzf-s -mfpu=vfp -mfloat-abi=hard" -DCMAKE_CXX_FLAGS="-mcpu=arm1176jzf-s -mfpu=vfp -mfloat-abi=hard"
           cmake --build build --target install
 
       # sin-cpp
@@ -2678,7 +3898,7 @@ jobs:
           -G"`python3 -c "import random; print(random.choice(['Ninja', 'Unix Makefiles']))"`" \
           -DCMAKE_INSTALL_PREFIX=../_install \
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-          -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc
+          -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_FLAGS="-mcpu=arm1176jzf-s -mfpu=vfp -mfloat-abi=hard" -DCMAKE_CXX_FLAGS="-mcpu=arm1176jzf-s -mfpu=vfp -mfloat-abi=hard"
       - name: Build
         shell: bash
         run: |
@@ -2761,7 +3981,7 @@ jobs:
       #      -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
       #      -GNinja \
       #      -DCMAKE_INSTALL_PREFIX=../_install \
-      #      -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
+      #      -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
       #    cmake --build build --target install
       - name: Google Test
         shell: bash
@@ -2775,7 +3995,7 @@ jobs:
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -GNinja \
             -DCMAKE_INSTALL_PREFIX=../_install \
-            -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
+            -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
           cmake --build build --target install
       - name: zlib
         shell: bash
@@ -2788,7 +4008,7 @@ jobs:
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -GNinja \
             -DCMAKE_INSTALL_PREFIX=../_install \
-            -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
+            -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
           cmake --build build --target install
 
       # sin-cpp
@@ -2801,7 +4021,7 @@ jobs:
           -G"`python3 -c "import random; print(random.choice(['Ninja', 'Unix Makefiles']))"`" \
           -DCMAKE_INSTALL_PREFIX=../_install \
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-          -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
+          -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
       - name: Build
         shell: bash
         run: |
@@ -2882,7 +4102,7 @@ jobs:
       #      -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
       #      -GNinja \
       #      -DCMAKE_INSTALL_PREFIX=../_install \
-      #      -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc
+      #      -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
       #    cmake --build build --target install
       - name: Google Test
         shell: bash
@@ -2896,7 +4116,7 @@ jobs:
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -GNinja \
             -DCMAKE_INSTALL_PREFIX=../_install \
-            -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc
+            -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
           cmake --build build --target install
       - name: zlib
         shell: bash
@@ -2909,7 +4129,7 @@ jobs:
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -GNinja \
             -DCMAKE_INSTALL_PREFIX=../_install \
-            -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc
+            -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
           cmake --build build --target install
 
       # sin-cpp
@@ -2922,7 +4142,7 @@ jobs:
           -G"`python3 -c "import random; print(random.choice(['Ninja', 'Unix Makefiles']))"`" \
           -DCMAKE_INSTALL_PREFIX=../_install \
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-          -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc
+          -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
       - name: Build
         shell: bash
         run: |
@@ -2935,13 +4155,13 @@ jobs:
           cd "$HOME/_ci_sin-cpp/sin-cpp/build"
           VERBOSE=1 PATH="../_install/bin:$PATH" ctest --output-on-failure
 
-  # macos14-amd64
+  # raspios13-armhf
 
-  macos14-amd64-apple-clang:
+  raspios13-armhf-clang:
     continue-on-error: true
     timeout-minutes: 600
-    runs-on: [ self-hosted, macos14-amd64 ]
-    name: macos14-amd64-apple-clang
+    runs-on: [ self-hosted, raspios13-armhf ]
+    name: raspios13-armhf-clang
     steps:
 
       # Clean
@@ -3005,7 +4225,7 @@ jobs:
       #      -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
       #      -GNinja \
       #      -DCMAKE_INSTALL_PREFIX=../_install \
-      #      -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
+      #      -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_FLAGS="-mcpu=arm1176jzf-s -mfpu=vfp -mfloat-abi=hard" -DCMAKE_CXX_FLAGS="-mcpu=arm1176jzf-s -mfpu=vfp -mfloat-abi=hard"
       #    cmake --build build --target install
       - name: Google Test
         shell: bash
@@ -3019,7 +4239,7 @@ jobs:
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -GNinja \
             -DCMAKE_INSTALL_PREFIX=../_install \
-            -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
+            -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_FLAGS="-mcpu=arm1176jzf-s -mfpu=vfp -mfloat-abi=hard" -DCMAKE_CXX_FLAGS="-mcpu=arm1176jzf-s -mfpu=vfp -mfloat-abi=hard"
           cmake --build build --target install
       - name: zlib
         shell: bash
@@ -3032,7 +4252,7 @@ jobs:
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -GNinja \
             -DCMAKE_INSTALL_PREFIX=../_install \
-            -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
+            -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_FLAGS="-mcpu=arm1176jzf-s -mfpu=vfp -mfloat-abi=hard" -DCMAKE_CXX_FLAGS="-mcpu=arm1176jzf-s -mfpu=vfp -mfloat-abi=hard"
           cmake --build build --target install
 
       # sin-cpp
@@ -3045,7 +4265,7 @@ jobs:
           -G"`python3 -c "import random; print(random.choice(['Ninja', 'Unix Makefiles']))"`" \
           -DCMAKE_INSTALL_PREFIX=../_install \
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-          -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
+          -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_FLAGS="-mcpu=arm1176jzf-s -mfpu=vfp -mfloat-abi=hard" -DCMAKE_CXX_FLAGS="-mcpu=arm1176jzf-s -mfpu=vfp -mfloat-abi=hard"
       - name: Build
         shell: bash
         run: |
@@ -3058,11 +4278,11 @@ jobs:
           cd "$HOME/_ci_sin-cpp/sin-cpp/build"
           VERBOSE=1 PATH="../_install/bin:$PATH" ctest --output-on-failure
 
-  macos14-amd64-clang:
+  raspios13-armhf-gcc:
     continue-on-error: true
     timeout-minutes: 600
-    runs-on: [ self-hosted, macos14-amd64 ]
-    name: macos14-amd64-clang
+    runs-on: [ self-hosted, raspios13-armhf ]
+    name: raspios13-armhf-gcc
     steps:
 
       # Clean
@@ -3126,7 +4346,7 @@ jobs:
       #      -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
       #      -GNinja \
       #      -DCMAKE_INSTALL_PREFIX=../_install \
-      #      -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++ LDFLAGS="-L/usr/local/opt/llvm/lib -L/usr/local/opt/llvm/lib/c++ -lunwind" CPPFLAGS=-I/usr/local/opt/llvm/include
+      #      -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
       #    cmake --build build --target install
       - name: Google Test
         shell: bash
@@ -3140,7 +4360,7 @@ jobs:
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -GNinja \
             -DCMAKE_INSTALL_PREFIX=../_install \
-            -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++ LDFLAGS="-L/usr/local/opt/llvm/lib -L/usr/local/opt/llvm/lib/c++ -lunwind" CPPFLAGS=-I/usr/local/opt/llvm/include
+            -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
           cmake --build build --target install
       - name: zlib
         shell: bash
@@ -3153,7 +4373,7 @@ jobs:
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -GNinja \
             -DCMAKE_INSTALL_PREFIX=../_install \
-            -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++ LDFLAGS="-L/usr/local/opt/llvm/lib -L/usr/local/opt/llvm/lib/c++ -lunwind" CPPFLAGS=-I/usr/local/opt/llvm/include
+            -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
           cmake --build build --target install
 
       # sin-cpp
@@ -3166,7 +4386,7 @@ jobs:
           -G"`python3 -c "import random; print(random.choice(['Ninja', 'Unix Makefiles']))"`" \
           -DCMAKE_INSTALL_PREFIX=../_install \
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-          -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++ LDFLAGS="-L/usr/local/opt/llvm/lib -L/usr/local/opt/llvm/lib/c++ -lunwind" CPPFLAGS=-I/usr/local/opt/llvm/include
+          -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
       - name: Build
         shell: bash
         run: |
@@ -3179,11 +4399,13 @@ jobs:
           cd "$HOME/_ci_sin-cpp/sin-cpp/build"
           VERBOSE=1 PATH="../_install/bin:$PATH" ctest --output-on-failure
 
-  macos14-amd64-gcc:
+  # raspios13-arm64
+
+  raspios13-arm64-clang:
     continue-on-error: true
     timeout-minutes: 600
-    runs-on: [ self-hosted, macos14-amd64 ]
-    name: macos14-amd64-gcc
+    runs-on: [ self-hosted, raspios13-arm64 ]
+    name: raspios13-arm64-clang
     steps:
 
       # Clean
@@ -3247,7 +4469,7 @@ jobs:
       #      -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
       #      -GNinja \
       #      -DCMAKE_INSTALL_PREFIX=../_install \
-      #      -DCMAKE_CXX_COMPILER=/usr/local/opt/gcc/bin/g++-14 -DCMAKE_OSX_SYSROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX14.sdk
+      #      -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
       #    cmake --build build --target install
       - name: Google Test
         shell: bash
@@ -3261,7 +4483,7 @@ jobs:
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -GNinja \
             -DCMAKE_INSTALL_PREFIX=../_install \
-            -DCMAKE_CXX_COMPILER=/usr/local/opt/gcc/bin/g++-14 -DCMAKE_OSX_SYSROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX14.sdk
+            -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
           cmake --build build --target install
       - name: zlib
         shell: bash
@@ -3274,7 +4496,7 @@ jobs:
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -GNinja \
             -DCMAKE_INSTALL_PREFIX=../_install \
-            -DCMAKE_CXX_COMPILER=/usr/local/opt/gcc/bin/g++-14 -DCMAKE_OSX_SYSROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX14.sdk
+            -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
           cmake --build build --target install
 
       # sin-cpp
@@ -3287,7 +4509,128 @@ jobs:
           -G"`python3 -c "import random; print(random.choice(['Ninja', 'Unix Makefiles']))"`" \
           -DCMAKE_INSTALL_PREFIX=../_install \
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-          -DCMAKE_CXX_COMPILER=/usr/local/opt/gcc/bin/g++-14 -DCMAKE_OSX_SYSROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX14.sdk
+          -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
+      - name: Build
+        shell: bash
+        run: |
+          cd "$HOME/_ci_sin-cpp/sin-cpp/build"
+          VERBOSE=1 PATH="../_install/bin:$PATH" cmake --version
+          VERBOSE=1 PATH="../_install/bin:$PATH" cmake --build .
+      - name: Tests
+        shell: bash
+        run: |
+          cd "$HOME/_ci_sin-cpp/sin-cpp/build"
+          VERBOSE=1 PATH="../_install/bin:$PATH" ctest --output-on-failure
+
+  raspios13-arm64-gcc:
+    continue-on-error: true
+    timeout-minutes: 600
+    runs-on: [ self-hosted, raspios13-arm64 ]
+    name: raspios13-arm64-gcc
+    steps:
+
+      # Clean
+      - name: Clean
+        run: |
+          rm -rf "$HOME/_ci_sin-cpp"
+          mkdir -p "$HOME/_ci_sin-cpp"
+
+      # Clone
+      - name: Clone Google Benchmark
+        uses: actions/checkout@v4
+        with:
+          repository: "google/benchmark"
+          path: 'benchmark'
+          fetch-depth: 1
+      - name: Clone Google Test
+        uses: actions/checkout@v4
+        with:
+          repository: "google/googletest"
+          path: 'googletest'
+          fetch-depth: 1
+      - name: Clone zlib
+        uses: actions/checkout@v4
+        with:
+          repository: "madler/zlib"
+          path: 'zlib'
+          fetch-depth: 1
+      - name: Clone sin-python
+        uses: actions/checkout@v4
+        with:
+          repository: 'sin-is-nsimd/sin-python'
+          path: 'sin-python'
+          fetch-depth: 1
+      - name: Clone sin-cmake
+        uses: actions/checkout@v4
+        with:
+          repository: 'sin-is-nsimd/sin-cmake'
+          path: 'sin-cmake'
+          fetch-depth: 1
+      - name: Clone sin-cpp
+        uses: actions/checkout@v4
+        with:
+          repository: 'sin-is-nsimd/sin-cpp'
+          path: 'sin-cpp'
+          fetch-depth: 1
+
+      # Move Repositories
+      - name: Move Repositories
+        run: cp -r * "$HOME/_ci_sin-cpp"
+
+      # Dependencies
+      #- name: Google Benchmark
+      #  shell: bash
+      #  run: |
+      #    cd "$HOME/_ci_sin-cpp/benchmark"
+      #    cmake \
+      #      -B build \
+      #      -DBENCHMARK_ENABLE_TESTING=OFF \
+      #      -DBENCHMARK_ENABLE_GTEST_TESTS=OFF \
+      #      -DCMAKE_BUILD_TYPE=Release \
+      #      -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+      #      -GNinja \
+      #      -DCMAKE_INSTALL_PREFIX=../_install \
+      #      -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
+      #    cmake --build build --target install
+      - name: Google Test
+        shell: bash
+        run: |
+          cd "$HOME/_ci_sin-cpp/googletest"
+          cmake \
+            -B build \
+            -DBUILD_GMOCK=OFF \
+            -Dgtest_build_tests=OFF -Dgtest_build_samples=OFF \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -GNinja \
+            -DCMAKE_INSTALL_PREFIX=../_install \
+            -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
+          cmake --build build --target install
+      - name: zlib
+        shell: bash
+        run: |
+          cd "$HOME/_ci_sin-cpp/zlib"
+          cmake \
+            -B build \
+            -DZLIB_BUILD_TESTING=OFF \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -GNinja \
+            -DCMAKE_INSTALL_PREFIX=../_install \
+            -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
+          cmake --build build --target install
+
+      # sin-cpp
+      - name: CMake
+        shell: bash
+        run: |
+          cd "$HOME/_ci_sin-cpp/sin-cpp"
+          VERBOSE=1 PATH="../_install/bin:$PATH" cmake --version
+          VERBOSE=1 PATH="../_install/bin:$PATH" cmake -B build -DCMAKE_BUILD_TYPE=Release \
+          -G"`python3 -c "import random; print(random.choice(['Ninja', 'Unix Makefiles']))"`" \
+          -DCMAKE_INSTALL_PREFIX=../_install \
+          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+          -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
       - name: Build
         shell: bash
         run: |
@@ -3370,7 +4713,7 @@ jobs:
       #      -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
       #      -GNinja \
       #      -DCMAKE_INSTALL_PREFIX=../_install \
-      #      -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
+      #       -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
       #    cmake --build build --target install
       - name: Google Test
         shell: bash
@@ -3384,7 +4727,7 @@ jobs:
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -GNinja \
             -DCMAKE_INSTALL_PREFIX=../_install \
-            -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
+             -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
           cmake --build build --target install
       - name: zlib
         shell: bash
@@ -3397,7 +4740,7 @@ jobs:
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -GNinja \
             -DCMAKE_INSTALL_PREFIX=../_install \
-            -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
+             -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
           cmake --build build --target install
 
       # sin-cpp
@@ -3410,7 +4753,7 @@ jobs:
           -G"`python3 -c "import random; print(random.choice(['Ninja', 'Unix Makefiles']))"`" \
           -DCMAKE_INSTALL_PREFIX=../_install \
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-          -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
+           -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
       - name: Build
         shell: bash
         run: |
@@ -3491,7 +4834,7 @@ jobs:
       #      -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
       #      -GNinja \
       #      -DCMAKE_INSTALL_PREFIX=../_install \
-      #      -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++ LDFLAGS="-L/usr/local/opt/llvm/lib -L/usr/local/opt/llvm/lib/c++ -lunwind" CPPFLAGS=-I/usr/local/opt/llvm/include
+      #      -DCMAKE_C_COMPILER=/usr/local/opt/llvm/bin/clang -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++ -DCMAKE_OSX_SYSROOT=macosx
       #    cmake --build build --target install
       - name: Google Test
         shell: bash
@@ -3505,7 +4848,7 @@ jobs:
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -GNinja \
             -DCMAKE_INSTALL_PREFIX=../_install \
-            -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++ LDFLAGS="-L/usr/local/opt/llvm/lib -L/usr/local/opt/llvm/lib/c++ -lunwind" CPPFLAGS=-I/usr/local/opt/llvm/include
+            -DCMAKE_C_COMPILER=/usr/local/opt/llvm/bin/clang -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++ -DCMAKE_OSX_SYSROOT=macosx
           cmake --build build --target install
       - name: zlib
         shell: bash
@@ -3518,7 +4861,7 @@ jobs:
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -GNinja \
             -DCMAKE_INSTALL_PREFIX=../_install \
-            -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++ LDFLAGS="-L/usr/local/opt/llvm/lib -L/usr/local/opt/llvm/lib/c++ -lunwind" CPPFLAGS=-I/usr/local/opt/llvm/include
+            -DCMAKE_C_COMPILER=/usr/local/opt/llvm/bin/clang -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++ -DCMAKE_OSX_SYSROOT=macosx
           cmake --build build --target install
 
       # sin-cpp
@@ -3531,7 +4874,7 @@ jobs:
           -G"`python3 -c "import random; print(random.choice(['Ninja', 'Unix Makefiles']))"`" \
           -DCMAKE_INSTALL_PREFIX=../_install \
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-          -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++ LDFLAGS="-L/usr/local/opt/llvm/lib -L/usr/local/opt/llvm/lib/c++ -lunwind" CPPFLAGS=-I/usr/local/opt/llvm/include
+          -DCMAKE_C_COMPILER=/usr/local/opt/llvm/bin/clang -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++ -DCMAKE_OSX_SYSROOT=macosx
       - name: Build
         shell: bash
         run: |
@@ -3612,7 +4955,7 @@ jobs:
       #      -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
       #      -GNinja \
       #      -DCMAKE_INSTALL_PREFIX=../_install \
-      #      -DCMAKE_CXX_COMPILER=/usr/local/opt/gcc/bin/g++-14 -DCMAKE_OSX_SYSROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk
+      #      -DCMAKE_C_COMPILER=/usr/local/bin/gcc-15 -DCMAKE_CXX_COMPILER=/usr/local/bin/g++-15 -DCMAKE_OSX_SYSROOT=macosx
       #    cmake --build build --target install
       - name: Google Test
         shell: bash
@@ -3626,7 +4969,7 @@ jobs:
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -GNinja \
             -DCMAKE_INSTALL_PREFIX=../_install \
-            -DCMAKE_CXX_COMPILER=/usr/local/opt/gcc/bin/g++-14 -DCMAKE_OSX_SYSROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk
+            -DCMAKE_C_COMPILER=/usr/local/bin/gcc-15 -DCMAKE_CXX_COMPILER=/usr/local/bin/g++-15 -DCMAKE_OSX_SYSROOT=macosx
           cmake --build build --target install
       - name: zlib
         shell: bash
@@ -3639,7 +4982,7 @@ jobs:
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -GNinja \
             -DCMAKE_INSTALL_PREFIX=../_install \
-            -DCMAKE_CXX_COMPILER=/usr/local/opt/gcc/bin/g++-14 -DCMAKE_OSX_SYSROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk
+            -DCMAKE_C_COMPILER=/usr/local/bin/gcc-15 -DCMAKE_CXX_COMPILER=/usr/local/bin/g++-15 -DCMAKE_OSX_SYSROOT=macosx
           cmake --build build --target install
 
       # sin-cpp
@@ -3652,7 +4995,7 @@ jobs:
           -G"`python3 -c "import random; print(random.choice(['Ninja', 'Unix Makefiles']))"`" \
           -DCMAKE_INSTALL_PREFIX=../_install \
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-          -DCMAKE_CXX_COMPILER=/usr/local/opt/gcc/bin/g++-14 -DCMAKE_OSX_SYSROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk
+          -DCMAKE_C_COMPILER=/usr/local/bin/gcc-15 -DCMAKE_CXX_COMPILER=/usr/local/bin/g++-15 -DCMAKE_OSX_SYSROOT=macosx
       - name: Build
         shell: bash
         run: |
@@ -3665,13 +5008,13 @@ jobs:
           cd "$HOME/_ci_sin-cpp/sin-cpp/build"
           VERBOSE=1 PATH="../_install/bin:$PATH" ctest --output-on-failure
 
-  # macos14-arm64
+  # macos26-amd64
 
-  macos14-arm64-apple-clang:
+  macos26-amd64-apple-clang:
     continue-on-error: true
     timeout-minutes: 600
-    runs-on: [ self-hosted, macos14-arm64 ]
-    name: macos14-arm64-apple-clang
+    runs-on: [ self-hosted, macos26-amd64 ]
+    name: macos26-amd64-apple-clang
     steps:
 
       # Clean
@@ -3735,7 +5078,7 @@ jobs:
       #      -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
       #      -GNinja \
       #      -DCMAKE_INSTALL_PREFIX=../_install \
-      #      -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
+      #       -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
       #    cmake --build build --target install
       - name: Google Test
         shell: bash
@@ -3749,7 +5092,7 @@ jobs:
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -GNinja \
             -DCMAKE_INSTALL_PREFIX=../_install \
-            -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
+             -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
           cmake --build build --target install
       - name: zlib
         shell: bash
@@ -3762,7 +5105,7 @@ jobs:
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -GNinja \
             -DCMAKE_INSTALL_PREFIX=../_install \
-            -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
+             -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
           cmake --build build --target install
 
       # sin-cpp
@@ -3775,7 +5118,7 @@ jobs:
           -G"`python3 -c "import random; print(random.choice(['Ninja', 'Unix Makefiles']))"`" \
           -DCMAKE_INSTALL_PREFIX=../_install \
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-          -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
+           -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
       - name: Build
         shell: bash
         run: |
@@ -3788,11 +5131,11 @@ jobs:
           cd "$HOME/_ci_sin-cpp/sin-cpp/build"
           VERBOSE=1 PATH="../_install/bin:$PATH" ctest --output-on-failure
 
-  macos14-arm64-clang:
+  macos26-amd64-clang:
     continue-on-error: true
     timeout-minutes: 600
-    runs-on: [ self-hosted, macos14-arm64 ]
-    name: macos14-arm64-clang
+    runs-on: [ self-hosted, macos26-amd64 ]
+    name: macos26-amd64-clang
     steps:
 
       # Clean
@@ -3856,7 +5199,7 @@ jobs:
       #      -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
       #      -GNinja \
       #      -DCMAKE_INSTALL_PREFIX=../_install \
-      #      -DCMAKE_CXX_COMPILER=/opt/homebrew/opt/llvm/bin/clang++ -DCMAKE_C_COMPILER=/opt/homebrew/opt/llvm/bin/clang LDFLAGS="-L/opt/homebrew/opt/llvm/lib/c++ -Wl,-rpath,/opt/homebrew/opt/llvm/lib/c++" CPPFLAGS="-I/opt/homebrew/opt/llvm/include"
+      #      -DCMAKE_C_COMPILER=/usr/local/opt/llvm/bin/clang -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++ -DCMAKE_OSX_SYSROOT=macosx
       #    cmake --build build --target install
       - name: Google Test
         shell: bash
@@ -3870,7 +5213,7 @@ jobs:
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -GNinja \
             -DCMAKE_INSTALL_PREFIX=../_install \
-            -DCMAKE_CXX_COMPILER=/opt/homebrew/opt/llvm/bin/clang++ -DCMAKE_C_COMPILER=/opt/homebrew/opt/llvm/bin/clang LDFLAGS="-L/opt/homebrew/opt/llvm/lib/c++ -Wl,-rpath,/opt/homebrew/opt/llvm/lib/c++" CPPFLAGS="-I/opt/homebrew/opt/llvm/include"
+            -DCMAKE_C_COMPILER=/usr/local/opt/llvm/bin/clang -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++ -DCMAKE_OSX_SYSROOT=macosx
           cmake --build build --target install
       - name: zlib
         shell: bash
@@ -3883,7 +5226,7 @@ jobs:
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -GNinja \
             -DCMAKE_INSTALL_PREFIX=../_install \
-            -DCMAKE_CXX_COMPILER=/opt/homebrew/opt/llvm/bin/clang++ -DCMAKE_C_COMPILER=/opt/homebrew/opt/llvm/bin/clang LDFLAGS="-L/opt/homebrew/opt/llvm/lib/c++ -Wl,-rpath,/opt/homebrew/opt/llvm/lib/c++" CPPFLAGS="-I/opt/homebrew/opt/llvm/include"
+            -DCMAKE_C_COMPILER=/usr/local/opt/llvm/bin/clang -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++ -DCMAKE_OSX_SYSROOT=macosx
           cmake --build build --target install
 
       # sin-cpp
@@ -3896,7 +5239,7 @@ jobs:
           -G"`python3 -c "import random; print(random.choice(['Ninja', 'Unix Makefiles']))"`" \
           -DCMAKE_INSTALL_PREFIX=../_install \
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-          -DCMAKE_CXX_COMPILER=/opt/homebrew/opt/llvm/bin/clang++ -DCMAKE_C_COMPILER=/opt/homebrew/opt/llvm/bin/clang LDFLAGS="-L/opt/homebrew/opt/llvm/lib/c++ -Wl,-rpath,/opt/homebrew/opt/llvm/lib/c++" CPPFLAGS="-I/opt/homebrew/opt/llvm/include"
+          -DCMAKE_C_COMPILER=/usr/local/opt/llvm/bin/clang -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++ -DCMAKE_OSX_SYSROOT=macosx
       - name: Build
         shell: bash
         run: |
@@ -3909,11 +5252,11 @@ jobs:
           cd "$HOME/_ci_sin-cpp/sin-cpp/build"
           VERBOSE=1 PATH="../_install/bin:$PATH" ctest --output-on-failure
 
-  macos14-arm64-gcc:
+  macos26-amd64-gcc:
     continue-on-error: true
     timeout-minutes: 600
-    runs-on: [ self-hosted, macos14-arm64 ]
-    name: macos14-arm64-gcc
+    runs-on: [ self-hosted, macos26-amd64 ]
+    name: macos26-amd64-gcc
     steps:
 
       # Clean
@@ -3977,7 +5320,7 @@ jobs:
       #      -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
       #      -GNinja \
       #      -DCMAKE_INSTALL_PREFIX=../_install \
-      #      -DCMAKE_CXX_COMPILER=/opt/homebrew/opt/gcc/bin/g++-14 -DCMAKE_C_COMPILER=/opt/homebrew/opt/gcc/bin/gcc-14 -DCMAKE_OSX_SYSROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX14.sdk
+      #      -DCMAKE_C_COMPILER=/usr/local/bin/gcc-15 -DCMAKE_CXX_COMPILER=/usr/local/bin/g++-15 -DCMAKE_OSX_SYSROOT=macosx
       #    cmake --build build --target install
       - name: Google Test
         shell: bash
@@ -3991,7 +5334,7 @@ jobs:
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -GNinja \
             -DCMAKE_INSTALL_PREFIX=../_install \
-            -DCMAKE_CXX_COMPILER=/opt/homebrew/opt/gcc/bin/g++-14 -DCMAKE_C_COMPILER=/opt/homebrew/opt/gcc/bin/gcc-14 -DCMAKE_OSX_SYSROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX14.sdk
+            -DCMAKE_C_COMPILER=/usr/local/bin/gcc-15 -DCMAKE_CXX_COMPILER=/usr/local/bin/g++-15 -DCMAKE_OSX_SYSROOT=macosx
           cmake --build build --target install
       - name: zlib
         shell: bash
@@ -4004,7 +5347,7 @@ jobs:
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -GNinja \
             -DCMAKE_INSTALL_PREFIX=../_install \
-            -DCMAKE_CXX_COMPILER=/opt/homebrew/opt/gcc/bin/g++-14 -DCMAKE_C_COMPILER=/opt/homebrew/opt/gcc/bin/gcc-14 -DCMAKE_OSX_SYSROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX14.sdk
+            -DCMAKE_C_COMPILER=/usr/local/bin/gcc-15 -DCMAKE_CXX_COMPILER=/usr/local/bin/g++-15 -DCMAKE_OSX_SYSROOT=macosx
           cmake --build build --target install
 
       # sin-cpp
@@ -4017,372 +5360,7 @@ jobs:
           -G"`python3 -c "import random; print(random.choice(['Ninja', 'Unix Makefiles']))"`" \
           -DCMAKE_INSTALL_PREFIX=../_install \
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-          -DCMAKE_CXX_COMPILER=/opt/homebrew/opt/gcc/bin/g++-14 -DCMAKE_C_COMPILER=/opt/homebrew/opt/gcc/bin/gcc-14 -DCMAKE_OSX_SYSROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX14.sdk
-      - name: Build
-        shell: bash
-        run: |
-          cd "$HOME/_ci_sin-cpp/sin-cpp/build"
-          VERBOSE=1 PATH="../_install/bin:$PATH" cmake --version
-          VERBOSE=1 PATH="../_install/bin:$PATH" cmake --build .
-      - name: Tests
-        shell: bash
-        run: |
-          cd "$HOME/_ci_sin-cpp/sin-cpp/build"
-          VERBOSE=1 PATH="../_install/bin:$PATH" ctest --output-on-failure
-
-  # macos15-arm64
-
-  macos15-arm64-apple-clang:
-    continue-on-error: true
-    timeout-minutes: 600
-    runs-on: [ self-hosted, macos15-arm64 ]
-    name: macos15-arm64-apple-clang
-    steps:
-
-      # Clean
-      - name: Clean
-        run: |
-          rm -rf "$HOME/_ci_sin-cpp"
-          mkdir -p "$HOME/_ci_sin-cpp"
-
-      # Clone
-      - name: Clone Google Benchmark
-        uses: actions/checkout@v4
-        with:
-          repository: "google/benchmark"
-          path: 'benchmark'
-          fetch-depth: 1
-      - name: Clone Google Test
-        uses: actions/checkout@v4
-        with:
-          repository: "google/googletest"
-          path: 'googletest'
-          fetch-depth: 1
-      - name: Clone zlib
-        uses: actions/checkout@v4
-        with:
-          repository: "madler/zlib"
-          path: 'zlib'
-          fetch-depth: 1
-      - name: Clone sin-python
-        uses: actions/checkout@v4
-        with:
-          repository: 'sin-is-nsimd/sin-python'
-          path: 'sin-python'
-          fetch-depth: 1
-      - name: Clone sin-cmake
-        uses: actions/checkout@v4
-        with:
-          repository: 'sin-is-nsimd/sin-cmake'
-          path: 'sin-cmake'
-          fetch-depth: 1
-      - name: Clone sin-cpp
-        uses: actions/checkout@v4
-        with:
-          repository: 'sin-is-nsimd/sin-cpp'
-          path: 'sin-cpp'
-          fetch-depth: 1
-
-      # Move Repositories
-      - name: Move Repositories
-        run: cp -r * "$HOME/_ci_sin-cpp"
-
-      # Dependencies
-      #- name: Google Benchmark
-      #  shell: bash
-      #  run: |
-      #    cd "$HOME/_ci_sin-cpp/benchmark"
-      #    cmake \
-      #      -B build \
-      #      -DBENCHMARK_ENABLE_TESTING=OFF \
-      #      -DBENCHMARK_ENABLE_GTEST_TESTS=OFF \
-      #      -DCMAKE_BUILD_TYPE=Release \
-      #      -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-      #      -GNinja \
-      #      -DCMAKE_INSTALL_PREFIX=../_install \
-      #      -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
-      #    cmake --build build --target install
-      - name: Google Test
-        shell: bash
-        run: |
-          cd "$HOME/_ci_sin-cpp/googletest"
-          cmake \
-            -B build \
-            -DBUILD_GMOCK=OFF \
-            -Dgtest_build_tests=OFF -Dgtest_build_samples=OFF \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-            -GNinja \
-            -DCMAKE_INSTALL_PREFIX=../_install \
-            -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
-          cmake --build build --target install
-      - name: zlib
-        shell: bash
-        run: |
-          cd "$HOME/_ci_sin-cpp/zlib"
-          cmake \
-            -B build \
-            -DZLIB_BUILD_TESTING=OFF \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
-            -GNinja \
-            -DCMAKE_INSTALL_PREFIX=../_install \
-            -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
-          cmake --build build --target install
-
-      # sin-cpp
-      - name: CMake
-        shell: bash
-        run: |
-          cd "$HOME/_ci_sin-cpp/sin-cpp"
-          VERBOSE=1 PATH="../_install/bin:$PATH" cmake --version
-          VERBOSE=1 PATH="../_install/bin:$PATH" cmake -B build -DCMAKE_BUILD_TYPE=Release \
-          -G"`python3 -c "import random; print(random.choice(['Ninja', 'Unix Makefiles']))"`" \
-          -DCMAKE_INSTALL_PREFIX=../_install \
-          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-          -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
-      - name: Build
-        shell: bash
-        run: |
-          cd "$HOME/_ci_sin-cpp/sin-cpp/build"
-          VERBOSE=1 PATH="../_install/bin:$PATH" cmake --version
-          VERBOSE=1 PATH="../_install/bin:$PATH" cmake --build .
-      - name: Tests
-        shell: bash
-        run: |
-          cd "$HOME/_ci_sin-cpp/sin-cpp/build"
-          VERBOSE=1 PATH="../_install/bin:$PATH" ctest --output-on-failure
-
-  macos15-arm64-clang:
-    continue-on-error: true
-    timeout-minutes: 600
-    runs-on: [ self-hosted, macos15-arm64 ]
-    name: macos15-arm64-clang
-    steps:
-
-      # Clean
-      - name: Clean
-        run: |
-          rm -rf "$HOME/_ci_sin-cpp"
-          mkdir -p "$HOME/_ci_sin-cpp"
-
-      # Clone
-      - name: Clone Google Benchmark
-        uses: actions/checkout@v4
-        with:
-          repository: "google/benchmark"
-          path: 'benchmark'
-          fetch-depth: 1
-      - name: Clone Google Test
-        uses: actions/checkout@v4
-        with:
-          repository: "google/googletest"
-          path: 'googletest'
-          fetch-depth: 1
-      - name: Clone zlib
-        uses: actions/checkout@v4
-        with:
-          repository: "madler/zlib"
-          path: 'zlib'
-          fetch-depth: 1
-      - name: Clone sin-python
-        uses: actions/checkout@v4
-        with:
-          repository: 'sin-is-nsimd/sin-python'
-          path: 'sin-python'
-          fetch-depth: 1
-      - name: Clone sin-cmake
-        uses: actions/checkout@v4
-        with:
-          repository: 'sin-is-nsimd/sin-cmake'
-          path: 'sin-cmake'
-          fetch-depth: 1
-      - name: Clone sin-cpp
-        uses: actions/checkout@v4
-        with:
-          repository: 'sin-is-nsimd/sin-cpp'
-          path: 'sin-cpp'
-          fetch-depth: 1
-
-      # Move Repositories
-      - name: Move Repositories
-        run: cp -r * "$HOME/_ci_sin-cpp"
-
-      # Dependencies
-      #- name: Google Benchmark
-      #  shell: bash
-      #  run: |
-      #    cd "$HOME/_ci_sin-cpp/benchmark"
-      #    cmake \
-      #      -B build \
-      #      -DBENCHMARK_ENABLE_TESTING=OFF \
-      #      -DBENCHMARK_ENABLE_GTEST_TESTS=OFF \
-      #      -DCMAKE_BUILD_TYPE=Release \
-      #      -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-      #      -GNinja \
-      #      -DCMAKE_INSTALL_PREFIX=../_install \
-      #      -DCMAKE_CXX_COMPILER=/opt/homebrew/opt/llvm/bin/clang++ -DCMAKE_C_COMPILER=/opt/homebrew/opt/llvm/bin/clang LDFLAGS="-L/opt/homebrew/opt/llvm/lib/c++ -Wl,-rpath,/opt/homebrew/opt/llvm/lib/c++" CPPFLAGS="-I/opt/homebrew/opt/llvm/include"
-      #    cmake --build build --target install
-      - name: Google Test
-        shell: bash
-        run: |
-          cd "$HOME/_ci_sin-cpp/googletest"
-          cmake \
-            -B build \
-            -DBUILD_GMOCK=OFF \
-            -Dgtest_build_tests=OFF -Dgtest_build_samples=OFF \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-            -GNinja \
-            -DCMAKE_INSTALL_PREFIX=../_install \
-            -DCMAKE_CXX_COMPILER=/opt/homebrew/opt/llvm/bin/clang++ -DCMAKE_C_COMPILER=/opt/homebrew/opt/llvm/bin/clang LDFLAGS="-L/opt/homebrew/opt/llvm/lib/c++ -Wl,-rpath,/opt/homebrew/opt/llvm/lib/c++" CPPFLAGS="-I/opt/homebrew/opt/llvm/include"
-          cmake --build build --target install
-      - name: zlib
-        shell: bash
-        run: |
-          cd "$HOME/_ci_sin-cpp/zlib"
-          cmake \
-            -B build \
-            -DZLIB_BUILD_TESTING=OFF \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
-            -GNinja \
-            -DCMAKE_INSTALL_PREFIX=../_install \
-            -DCMAKE_CXX_COMPILER=/opt/homebrew/opt/llvm/bin/clang++ -DCMAKE_C_COMPILER=/opt/homebrew/opt/llvm/bin/clang LDFLAGS="-L/opt/homebrew/opt/llvm/lib/c++ -Wl,-rpath,/opt/homebrew/opt/llvm/lib/c++" CPPFLAGS="-I/opt/homebrew/opt/llvm/include"
-          cmake --build build --target install
-
-      # sin-cpp
-      - name: CMake
-        shell: bash
-        run: |
-          cd "$HOME/_ci_sin-cpp/sin-cpp"
-          VERBOSE=1 PATH="../_install/bin:$PATH" cmake --version
-          VERBOSE=1 PATH="../_install/bin:$PATH" cmake -B build -DCMAKE_BUILD_TYPE=Release \
-          -G"`python3 -c "import random; print(random.choice(['Ninja', 'Unix Makefiles']))"`" \
-          -DCMAKE_INSTALL_PREFIX=../_install \
-          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-          -DCMAKE_CXX_COMPILER=/opt/homebrew/opt/llvm/bin/clang++ -DCMAKE_C_COMPILER=/opt/homebrew/opt/llvm/bin/clang LDFLAGS="-L/opt/homebrew/opt/llvm/lib/c++ -Wl,-rpath,/opt/homebrew/opt/llvm/lib/c++" CPPFLAGS="-I/opt/homebrew/opt/llvm/include"
-      - name: Build
-        shell: bash
-        run: |
-          cd "$HOME/_ci_sin-cpp/sin-cpp/build"
-          VERBOSE=1 PATH="../_install/bin:$PATH" cmake --version
-          VERBOSE=1 PATH="../_install/bin:$PATH" cmake --build .
-      - name: Tests
-        shell: bash
-        run: |
-          cd "$HOME/_ci_sin-cpp/sin-cpp/build"
-          VERBOSE=1 PATH="../_install/bin:$PATH" ctest --output-on-failure
-
-  macos15-arm64-gcc:
-    continue-on-error: true
-    timeout-minutes: 600
-    runs-on: [ self-hosted, macos15-arm64 ]
-    name: macos15-arm64-gcc
-    steps:
-
-      # Clean
-      - name: Clean
-        run: |
-          rm -rf "$HOME/_ci_sin-cpp"
-          mkdir -p "$HOME/_ci_sin-cpp"
-
-      # Clone
-      - name: Clone Google Benchmark
-        uses: actions/checkout@v4
-        with:
-          repository: "google/benchmark"
-          path: 'benchmark'
-          fetch-depth: 1
-      - name: Clone Google Test
-        uses: actions/checkout@v4
-        with:
-          repository: "google/googletest"
-          path: 'googletest'
-          fetch-depth: 1
-      - name: Clone zlib
-        uses: actions/checkout@v4
-        with:
-          repository: "madler/zlib"
-          path: 'zlib'
-          fetch-depth: 1
-      - name: Clone sin-python
-        uses: actions/checkout@v4
-        with:
-          repository: 'sin-is-nsimd/sin-python'
-          path: 'sin-python'
-          fetch-depth: 1
-      - name: Clone sin-cmake
-        uses: actions/checkout@v4
-        with:
-          repository: 'sin-is-nsimd/sin-cmake'
-          path: 'sin-cmake'
-          fetch-depth: 1
-      - name: Clone sin-cpp
-        uses: actions/checkout@v4
-        with:
-          repository: 'sin-is-nsimd/sin-cpp'
-          path: 'sin-cpp'
-          fetch-depth: 1
-
-      # Move Repositories
-      - name: Move Repositories
-        run: cp -r * "$HOME/_ci_sin-cpp"
-
-      # Dependencies
-      #- name: Google Benchmark
-      #  shell: bash
-      #  run: |
-      #    cd "$HOME/_ci_sin-cpp/benchmark"
-      #    cmake \
-      #      -B build \
-      #      -DBENCHMARK_ENABLE_TESTING=OFF \
-      #      -DBENCHMARK_ENABLE_GTEST_TESTS=OFF \
-      #      -DCMAKE_BUILD_TYPE=Release \
-      #      -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-      #      -GNinja \
-      #      -DCMAKE_INSTALL_PREFIX=../_install \
-      #      -DCMAKE_CXX_COMPILER=/opt/homebrew/opt/gcc/bin/g++-14 -DCMAKE_C_COMPILER=/opt/homebrew/opt/gcc/bin/gcc-14 -DCMAKE_OSX_SYSROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk
-      #    cmake --build build --target install
-      - name: Google Test
-        shell: bash
-        run: |
-          cd "$HOME/_ci_sin-cpp/googletest"
-          cmake \
-            -B build \
-            -DBUILD_GMOCK=OFF \
-            -Dgtest_build_tests=OFF -Dgtest_build_samples=OFF \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-            -GNinja \
-            -DCMAKE_INSTALL_PREFIX=../_install \
-            -DCMAKE_CXX_COMPILER=/opt/homebrew/opt/gcc/bin/g++-14 -DCMAKE_C_COMPILER=/opt/homebrew/opt/gcc/bin/gcc-14 -DCMAKE_OSX_SYSROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk
-          cmake --build build --target install
-      - name: zlib
-        shell: bash
-        run: |
-          cd "$HOME/_ci_sin-cpp/zlib"
-          cmake \
-            -B build \
-            -DZLIB_BUILD_TESTING=OFF \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
-            -GNinja \
-            -DCMAKE_INSTALL_PREFIX=../_install \
-            -DCMAKE_CXX_COMPILER=/opt/homebrew/opt/gcc/bin/g++-14 -DCMAKE_C_COMPILER=/opt/homebrew/opt/gcc/bin/gcc-14 -DCMAKE_OSX_SYSROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk
-          cmake --build build --target install
-
-      # sin-cpp
-      - name: CMake
-        shell: bash
-        run: |
-          cd "$HOME/_ci_sin-cpp/sin-cpp"
-          VERBOSE=1 PATH="../_install/bin:$PATH" cmake --version
-          VERBOSE=1 PATH="../_install/bin:$PATH" cmake -B build -DCMAKE_BUILD_TYPE=Release \
-          -G"`python3 -c "import random; print(random.choice(['Ninja', 'Unix Makefiles']))"`" \
-          -DCMAKE_INSTALL_PREFIX=../_install \
-          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-          -DCMAKE_CXX_COMPILER=/opt/homebrew/opt/gcc/bin/g++-14 -DCMAKE_C_COMPILER=/opt/homebrew/opt/gcc/bin/gcc-14 -DCMAKE_OSX_SYSROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk
+          -DCMAKE_C_COMPILER=/usr/local/bin/gcc-15 -DCMAKE_CXX_COMPILER=/usr/local/bin/g++-15 -DCMAKE_OSX_SYSROOT=macosx
       - name: Build
         shell: bash
         run: |

--- a/ci/generate_workflows.py
+++ b/ci/generate_workflows.py
@@ -3,7 +3,7 @@
 
 """Generate github action workflows."""
 
-# Copyright © 2023-2025 Lénaïc Bagnères, lenaicb@singularity.fr
+# Copyright © 2023-2026 Lénaïc Bagnères, lenaicb@singularity.fr
 # Copyright © 2024 Rodolphe Cargnello, rodolphe.cargnello@gmail.com
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -30,7 +30,9 @@ import sys
 
 config: dict[str, Any] = {}
 
-# debian + raspios + manjaro
+# raspios armhf flags
+raspios_armhf_flags = ' -DCMAKE_C_FLAGS="-mcpu=arm1176jzf-s -mfpu=vfp -mfloat-abi=hard" -DCMAKE_CXX_FLAGS="-mcpu=arm1176jzf-s -mfpu=vfp -mfloat-abi=hard"'
+# debian + raspios
 for system in [
     # debian12
     "debian12-amd64",
@@ -44,9 +46,18 @@ for system in [
     "debian13-armhf",
     "debian13-arm64",
     "debian13-ppc64el",
+    # debian14
+    "debian14-amd64",
+    "debian14-i386",
+    "debian14-armhf",
+    "debian14-arm64",
+    "debian14-ppc64el",
     # raspios12
     "raspios12-armhf",
     "raspios12-arm64",
+    # raspios13
+    "raspios13-armhf",
+    "raspios13-arm64",
 ]:
     config.update(
         {
@@ -54,11 +65,19 @@ for system in [
                 "compilers_args": [
                     {
                         "name": "clang",
-                        "args": "-DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang",
+                        "args": "-DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++"
+                        + (
+                            raspios_armhf_flags
+                            if system in ["raspios12-armhf", "raspios13-armhf"]
+                            else ""
+                        ),
                     },
                     {
                         "name": "gcc",
-                        "args": "-DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc",
+                        "args": "-DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++"
+                        + (
+                            raspios_armhf_flags if system in ["raspios12-armhf"] else ""
+                        ),
                     },
                 ]
             },
@@ -66,50 +85,49 @@ for system in [
     )
 
 # macOS
-for version in ["14", "15"]:
-    system = "macos" + version + "-amd64"
+for system in ["macos15-amd64", "macos26-amd64"]:
     config.update(
         {
             system: {
                 "compilers_args": [
                     {
                         "name": "apple-clang",
-                        "args": "-DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang",
+                        "args": " -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++",
                     },
                     {
                         "name": "clang",
-                        "args": '-DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++ LDFLAGS="-L/usr/local/opt/llvm/lib -L/usr/local/opt/llvm/lib/c++ -lunwind" CPPFLAGS=-I/usr/local/opt/llvm/include',
+                        "args": "-DCMAKE_C_COMPILER=/usr/local/opt/llvm/bin/clang -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++ -DCMAKE_OSX_SYSROOT=macosx",
                     },
                     {
                         "name": "gcc",
-                        "args": f"-DCMAKE_CXX_COMPILER=/usr/local/opt/gcc/bin/g++-14 -DCMAKE_OSX_SYSROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX{version}.sdk",
+                        "args": f"-DCMAKE_C_COMPILER=/usr/local/bin/gcc-15 -DCMAKE_CXX_COMPILER=/usr/local/bin/g++-15 -DCMAKE_OSX_SYSROOT=macosx",
                     },
                 ]
             },
         }
     )
-for version in ["14", "15"]:
-    system = "macos" + version + "-arm64"
-    config.update(
-        {
-            system: {
-                "compilers_args": [
-                    {
-                        "name": "apple-clang",
-                        "args": "-DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang",
-                    },
-                    {
-                        "name": "clang",
-                        "args": '-DCMAKE_CXX_COMPILER=/opt/homebrew/opt/llvm/bin/clang++ -DCMAKE_C_COMPILER=/opt/homebrew/opt/llvm/bin/clang LDFLAGS="-L/opt/homebrew/opt/llvm/lib/c++ -Wl,-rpath,/opt/homebrew/opt/llvm/lib/c++" CPPFLAGS="-I/opt/homebrew/opt/llvm/include"',
-                    },
-                    {
-                        "name": "gcc",
-                        "args": f"-DCMAKE_CXX_COMPILER=/opt/homebrew/opt/gcc/bin/g++-14 -DCMAKE_C_COMPILER=/opt/homebrew/opt/gcc/bin/gcc-14 -DCMAKE_OSX_SYSROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX{version}.sdk",
-                    },
-                ]
-            },
-        }
-    )
+# for version in ["15", "26"]:
+#     system = "macos" + version + "-arm64"
+#     config.update(
+#         {
+#             system: {
+#                 "compilers_args": [
+#                     {
+#                         "name": "apple-clang",
+#                         "args": " -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++",
+#                     },
+#                     {
+#                         "name": "clang",
+#                         "args": '-DCMAKE_C_COMPILER=/opt/homebrew/opt/llvm/bin/clang CFLAGS="-I/opt/homebrew/opt/llvm/include" -DCMAKE_CXX_COMPILER=/opt/homebrew/opt/llvm/bin/clang++ CPPFLAGS="-I/opt/homebrew/opt/llvm/include" LDFLAGS="-L/opt/homebrew/opt/llvm/lib/c++ -Wl,-rpath,/opt/homebrew/opt/llvm/lib/c++"',
+#                     },
+#                     {
+#                         "name": "gcc",
+#                         "args": f"-DCMAKE_C_COMPILER=/opt/homebrew/opt/gcc/bin/gcc-14 -DCMAKE_CXX_COMPILER=/opt/homebrew/opt/gcc/bin/g++-14-DCMAKE_OSX_SYSROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX{version}.sdk",
+#                     },
+#                 ]
+#             },
+#         }
+#     )
 
 # Windows
 for system in ["windows10-amd64", "windows10-i386", "windows11-amd64"]:
@@ -353,10 +371,12 @@ if __name__ == "__main__":
 
             for compilers_args in configs["compilers_args"]:
 
+                job = f"{system}-{compilers_args['name']}".lower()
+
                 # Header
                 f.write(
                     runner.format(
-                        job=f"{system}-{compilers_args['name']}".lower(),
+                        job=job,
                         system=system,
                     )
                 )


### PR DESCRIPTION
Changes in CI:
- Update after re-installation of all runners
- Temporary deactivate `macos*-arm64` runners
- Add `debian14*` runners

Notes:
- `.github/workflows/ci_generated.yml` is generated
- I installed `clang 15` (using `apt`) on `raspios12-arm64-clang` (instead of `clang 14.0.6`)
- `clang 14.0.6` failed on `raspios12-arm64-clang` but works on `raspios12-armhf`,  `debian12-armhf`,  `debian12-arm64`, `debian12-i386`,  `debian12-amd64`,  `debian12-ppc64el`,  `debian12-armhf`
- Possible error on `raspios12-arm64-clang`:
```
⭐ Run Main Google Test
-- The C compiler identification is Clang 14.0.6
-- The CXX compiler identification is Clang 14.0.6
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - failed
-- Check for working C compiler: /usr/bin/clang
-- Check for working C compiler: /usr/bin/clang - broken
CMake Error at /usr/share/cmake-3.25/Modules/CMakeTestCCompiler.cmake:70 (message):
  The C compiler

    "/usr/bin/clang"

  is not able to compile a simple test program.

  It fails with the following output:

    Change Dir: /home/sin/_ci_sin-cpp/googletest/build/CMakeFiles/CMakeScratch/TryCompile-fTg5SF
    
    Run Build Command(s):/usr/bin/ninja cmTC_8a587 && [1/2] Building C object CMakeFiles/cmTC_8a587.dir/testCCompiler.c.o
    FAILED: CMakeFiles/cmTC_8a587.dir/testCCompiler.c.o 
    /usr/bin/clang    -MD -MT CMakeFiles/cmTC_8a587.dir/testCCompiler.c.o -MF CMakeFiles/cmTC_8a587.dir/testCCompiler.c.o.d -o CMakeFiles/cmTC_8a587.dir/testCCompiler.c.o -c /home/sin/_ci_sin-cpp/googletest/build/CMakeFiles/CMakeScratch/TryCompile-fTg5SF/testCCompiler.c
    PLEASE submit a bug report to https://github.com/llvm/llvm-project/issues/ and include the crash backtrace, preprocessed source, and associated run script.
    Stack dump:
    0.	Program arguments: /usr/bin/clang -MD -MT CMakeFiles/cmTC_8a587.dir/testCCompiler.c.o -MF CMakeFiles/cmTC_8a587.dir/testCCompiler.c.o.d -o CMakeFiles/cmTC_8a587.dir/testCCompiler.c.o -c /home/sin/_ci_sin-cpp/googletest/build/CMakeFiles/CMakeScratch/TryCompile-fTg5SF/testCCompiler.c
    1.	<eof> parser at end of file
Error:   ❌  Failure - Main Google Test
    2.	Code generation
    3.	Running pass 'Function Pass Manager' on module '/home/sin/_ci_sin-cpp/googletest/build/CMakeFiles/CMakeScratch/TryCompile-fTg5SF/testCCompiler.c'.
Error: exit status 1
    4.	Running pass 'AArch64 Assembly Printer' on function '@main'
     #0 0x0000007f8488e4dc llvm::sys::PrintStackTrace(llvm::raw_ostream&, int) (/lib/aarch64-linux-gnu/libLLVM-14.so.1+0xe9e4dc)
     #1 0x0000007f8488c4b4 llvm::sys::RunSignalHandlers() (/lib/aarch64-linux-gnu/libLLVM-14.so.1+0xe9c4b4)
     #2 0x0000007f847bb1c0 (/lib/aarch64-linux-gnu/libLLVM-14.so.1+0xdcb1c0)
     #3 0x0000007f8d102820 (linux-vdso.so.1+0x820)
     #4 0x0000007f84d1a9f0 (/lib/aarch64-linux-gnu/libLLVM-14.so.1+0x132a9f0)
     #5 0x0000007f8486b49c llvm::raw_ostream::write(char const*, unsigned long) (/lib/aarch64-linux-gnu/libLLVM-14.so.1+0xe7b49c)
     #6 0x0000007f85c21048 llvm::MCContext::createTempSymbol(llvm::Twine const&, bool) (/lib/aarch64-linux-gnu/libLLVM-14.so.1+0x2231048)
     #7 0x0000007f85c213f0 llvm::MCContext::createTempSymbol() (/lib/aarch64-linux-gnu/libLLVM-14.so.1+0x22313f0)
     #8 0x0000007f85c45c6c llvm::MCObjectStreamer::emitCFIEndProcImpl(llvm::MCDwarfFrameInfo&) (/lib/aarch64-linux-gnu/libLLVM-14.so.1+0x2255c6c)
     #9 0x0000007f8504f4c0 (/lib/aarch64-linux-gnu/libLLVM-14.so.1+0x165f4c0)
    #10 0x0000007f85030b6c llvm::AsmPrinter::emitFunctionBody() (/lib/aarch64-linux-gnu/libLLVM-14.so.1+0x1640b6c)
    #11 0x0000007f86154ba4 (/lib/aarch64-linux-gnu/libLLVM-14.so.1+0x2764ba4)
    #12 0x0000007f84be122c llvm::MachineFunctionPass::runOnFunction(llvm::Function&) (/lib/aarch64-linux-gnu/libLLVM-14.so.1+0x11f122c)
    #13 0x0000007f849c4390 llvm::FPPassManager::runOnFunction(llvm::Function&) (/lib/aarch64-linux-gnu/libLLVM-14.so.1+0xfd4390)
    #14 0x0000007f849caf70 llvm::FPPassManager::runOnModule(llvm::Module&) (/lib/aarch64-linux-gnu/libLLVM-14.so.1+0xfdaf70)
    #15 0x0000007f849c4d98 llvm::legacy::PassManagerImpl::run(llvm::Module&) (/lib/aarch64-linux-gnu/libLLVM-14.so.1+0xfd4d98)
    #16 0x0000007f8b4cc680 clang::EmitBackendOutput(clang::DiagnosticsEngine&, clang::HeaderSearchOptions const&, clang::CodeGenOptions const&, clang::TargetOptions const&, clang::LangOptions const&, llvm::StringRef, llvm::Module*, clang::BackendAction, std::unique_ptr<llvm::raw_pwrite_stream, std::default_delete<llvm::raw_pwrite_stream> >) (/lib/aarch64-linux-gnu/libclang-cpp.so.14+0x184c680)
    #17 0x0000007f8b786f20 (/lib/aarch64-linux-gnu/libclang-cpp.so.14+0x1b06f20)
    #18 0x0000007f8a6c6f1c clang::ParseAST(clang::Sema&, bool, bool) (/lib/aarch64-linux-gnu/libclang-cpp.so.14+0xa46f1c)
    #19 0x0000007f8c084444 clang::FrontendAction::Execute() (/lib/aarch64-linux-gnu/libclang-cpp.so.14+0x2404444)
```
- Other error on `raspios12-arm64-clang` (sometimes, the error above did not occur):
```
⭐ Run Main Google Test
-- The C compiler identification is Clang 14.0.6
-- The CXX compiler identification is Clang 14.0.6
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/clang - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/clang++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Failed
-- Looking for pthread_create in pthreads
-- Looking for pthread_create in pthreads - not found
-- Looking for pthread_create in pthread
-- Looking for pthread_create in pthread - found
-- Found Threads: TRUE  
-- Configuring done
-- Generating done
-- Build files have been written to: /home/sin/_ci_sin-cpp/googletest/build
[1/5] Building CXX object googletest/CMakeFiles/gtest.dir/src/gtest-all.cc.o
FAILED: googletest/CMakeFiles/gtest.dir/src/gtest-all.cc.o 
ccache /usr/bin/clang++  -I/home/sin/_ci_sin-cpp/googletest/googletest/include -I/home/sin/_ci_sin-cpp/googletest/googletest -O3 -DNDEBUG -Wall -Wshadow -Wconversion -Wundef -DGTEST_HAS_PTHREAD=1 -fexceptions -W -Wpointer-arith -Wreturn-type -Wcast-qual -Wwrite-strings -Wswitch -Wunused-parameter -Wcast-align -Winline -Wredundant-decls -Wchar-subscripts -std=c++17 -MD -MT googletest/CMakeFiles/gtest.dir/src/gtest-all.cc.o -MF googletest/CMakeFiles/gtest.dir/src/gtest-all.cc.o.d -o googletest/CMakeFiles/gtest.dir/src/gtest-all.cc.o -c /home/sin/_ci_sin-cpp/googletest/googletest/src/gtest-all.cc
PLEASE submit a bug report to https://github.com/llvm/llvm-project/issues/ and include the crash backtrace, preprocessed source, and associated run script.
Stack dump:
0.	Program arguments: /usr/bin/clang++ -O3 -Wall -Wshadow -Wconversion -Wundef -fexceptions -W -Wpointer-arith -Wreturn-type -Wcast-qual -Wwrite-strings -Wswitch -Wunused-parameter -Wcast-align -Winline -Wredundant-decls -Wchar-subscripts -std=c++17 -I/home/sin/_ci_sin-cpp/googletest/googletest/include -I/home/sin/_ci_sin-cpp/googletest/googletest -DNDEBUG -DGTEST_HAS_PTHREAD=1 -c -MD -MT googletest/CMakeFiles/gtest.dir/src/gtest-all.cc.o -MF googletest/CMakeFiles/gtest.dir/src/gtest-all.cc.o.d -fcolor-diagnostics -o googletest/CMakeFiles/gtest.dir/src/gtest-all.cc.o /home/sin/_ci_sin-cpp/googletest/googletest/src/gtest-all.cc
1.	<eof> parser at end of file
Error:   ❌  Failure - Main Google Test
Error: exit status 1
2.	Code generation
3.	Running pass 'Function Pass Manager' on module '/home/sin/_ci_sin-cpp/googletest/googletest/src/gtest-all.cc'.
4.	Running pass 'AArch64 Assembly Printer' on function '@_ZNK7testing15AssertionResultntEv'
 #0 0x0000007fa038e4dc llvm::sys::PrintStackTrace(llvm::raw_ostream&, int) (/lib/aarch64-linux-gnu/libLLVM-14.so.1+0xe9e4dc)
 #1 0x0000007fa038c4b4 llvm::sys::RunSignalHandlers() (/lib/aarch64-linux-gnu/libLLVM-14.so.1+0xe9c4b4)
 #2 0x0000007fa02bb1c0 (/lib/aarch64-linux-gnu/libLLVM-14.so.1+0xdcb1c0)
 #3 0x0000007fa8c05820 (linux-vdso.so.1+0x820)
 #4 0x0000007fa081a9f0 (/lib/aarch64-linux-gnu/libLLVM-14.so.1+0x132a9f0)
 #5 0x0000007fa036b49c llvm::raw_ostream::write(char const*, unsigned long) (/lib/aarch64-linux-gnu/libLLVM-14.so.1+0xe7b49c)
 #6 0x0000007fa1721048 llvm::MCContext::createTempSymbol(llvm::Twine const&, bool) (/lib/aarch64-linux-gnu/libLLVM-14.so.1+0x2231048)
 #7 0x0000007fa17213f0 llvm::MCContext::createTempSymbol() (/lib/aarch64-linux-gnu/libLLVM-14.so.1+0x22313f0)
 #8 0x0000007fa1745c2c llvm::MCObjectStreamer::emitCFIStartProcImpl(llvm::MCDwarfFrameInfo&) (/lib/aarch64-linux-gnu/libLLVM-14.so.1+0x2255c2c)
 #9 0x0000007fa1756140 llvm::MCStreamer::emitCFIStartProc(bool, llvm::SMLoc) (/lib/aarch64-linux-gnu/libLLVM-14.so.1+0x2266140)
#10 0x0000007fa0b4f898 (/lib/aarch64-linux-gnu/libLLVM-14.so.1+0x165f898)
#11 0x0000007fa0b2d3d0 llvm::AsmPrinter::emitFunctionHeader() (/lib/aarch64-linux-gnu/libLLVM-14.so.1+0x163d3d0)
#12 0x0000007fa0b2e56c llvm::AsmPrinter::emitFunctionBody() (/lib/aarch64-linux-gnu/libLLVM-14.so.1+0x163e56c)
#13 0x0000007fa1c54ba4 (/lib/aarch64-linux-gnu/libLLVM-14.so.1+0x2764ba4)
#14 0x0000007fa06e122c llvm::MachineFunctionPass::runOnFunction(llvm::Function&) (/lib/aarch64-linux-gnu/libLLVM-14.so.1+0x11f122c)
#15 0x0000007fa04c4390 llvm::FPPassManager::runOnFunction(llvm::Function&) (/lib/aarch64-linux-gnu/libLLVM-14.so.1+0xfd4390)
#16 0x0000007fa04caf70 llvm::FPPassManager::runOnModule(llvm::Module&) (/lib/aarch64-linux-gnu/libLLVM-14.so.1+0xfdaf70)
#17 0x0000007fa04c4d98 llvm::legacy::PassManagerImpl::run(llvm::Module&) (/lib/aarch64-linux-gnu/libLLVM-14.so.1+0xfd4d98)
```